### PR TITLE
feat: add websockify for the socket proxy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,11 +20,20 @@ RUN apk update && apk add --no-cache \
     supervisor \
     bash \
     git \
-    python3 && \
+    python3 \
+    py3-pip \
+    py3-numpy \
+    py3-setuptools \
+    netcat-openbsd && \
     rm -rf /var/cache/apk/*
 
 # Clone the noVNC repository 
 RUN git clone https://github.com/novnc/noVNC.git /opt/noVNC
+
+# Clone and install websockify
+RUN git clone https://github.com/novnc/websockify.git /opt/websockify && \
+    cd /opt/websockify && \
+    pip3 install --break-system-packages .
 
 USER root
 # ---------------------------
@@ -58,4 +67,3 @@ EXPOSE 3000 5900 6080 6081
 
 # Set the default command to run Supervisor in non‑daemon mode.
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf", "-n"]
-

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -9,7 +9,7 @@ user=root
 [program:desktop-vm]
 ; Run a VM using QEMU in headless mode with VNC on display :0 (TCP port 5900)
 ; The script checks for HVF (macOS) or KVM (Linux) availability and enables appropriate acceleration
-command=sh -c 'if [ "$(uname)" = "Darwin" ] && [ -d "/Library/Apple/System/Library/Frameworks/Hypervisor.framework" ]; then ACCEL="-accel hvf"; elif [ -e /dev/kvm ]; then ACCEL="-accel kvm"; else ACCEL="-accel tcg"; fi; echo "Starting QEMU with VNC on port 5900 and no websocket"; qemu-system-x86_64 -m 8G -smp 4 $ACCEL -device qemu-xhci,id=xhci -device usb-tablet,bus=xhci.0 -drive file=/opt/bytebot-lubuntu-22.04.5.qcow2,format=qcow2 -vnc 0.0.0.0:0 -boot c -qmp unix:/tmp/qmp-sock,server,nowait; echo "QEMU exited with status $?"'
+command=sh -c 'if [ "$(uname)" = "Darwin" ] && [ -d "/Library/Apple/System/Library/Frameworks/Hypervisor.framework" ]; then ACCEL="-accel hvf"; elif [ -e /dev/kvm ]; then ACCEL="-accel kvm"; else ACCEL="-accel tcg"; fi; echo "Starting QEMU with VNC on port 5900"; qemu-system-x86_64 -m 8G -smp 4 $ACCEL -device qemu-xhci,id=xhci -device usb-tablet,bus=xhci.0 -drive file=/opt/bytebot-lubuntu-22.04.5.qcow2,format=qcow2 -vnc 0.0.0.0:0 -boot c -qmp unix:/tmp/qmp-sock,server,nowait; echo "QEMU exited with status $?"'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
@@ -17,8 +17,8 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:hypervisor]
-; Start the hypervisor after waiting for the VM to boot up
-command=sh -c 'echo "Waiting for QEMU VM to boot up and VNC to be available..."; while ! nc -z localhost 5900; do echo "Waiting for VNC port 5900..."; sleep 2; done; echo "VNC port is available, starting hypervisor"; exec node /hypervisor/dist/main.js'
+; Start the hypervisor after waiting for websockify to be ready
+command=sh -c 'echo "Waiting for websockify on port 6080 (hypervisor)..."; while ! nc -z localhost 6080; do sleep 2; done; echo "Websockify is ready, starting hypervisor"; exec node /hypervisor/dist/main.js'
 directory=/hypervisor
 autostart=true
 autorestart=true
@@ -28,8 +28,8 @@ redirect_stderr=true
 
 [program:novnc-http]
 ; Serve the noVNC client files using Python's HTTP server on port 6081.
-; Start without waiting for port 6080
-command=sh -c 'echo "Starting noVNC HTTP server on port 6081 without waiting for port 6080"; sleep 5; echo "Network ports:"; netstat -tuln; exec python3 -m http.server 6081 --directory /opt/noVNC'
+; Wait for websockify to be ready on port 6080
+command=sh -c 'echo "Waiting for websockify on port 6080 (noVNC)..."; while ! nc -z localhost 6080; do sleep 2; done; echo "Websockify is ready, starting noVNC HTTP server on port 6081"; exec python3 -m http.server 6081 --directory /opt/noVNC'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -9,35 +9,38 @@ user=root
 [program:desktop-vm]
 ; Run a VM using QEMU in headless mode with VNC on display :0 (TCP port 5900)
 ; The script checks for HVF (macOS) or KVM (Linux) availability and enables appropriate acceleration
-command=sh -c 'if [ "$(uname)" = "Darwin" ] && [ -d "/Library/Apple/System/Library/Frameworks/Hypervisor.framework" ]; then ACCEL="-accel hvf"; elif [ -e /dev/kvm ]; then ACCEL="-accel kvm"; else ACCEL="-accel tcg"; fi; exec qemu-system-x86_64 -m 8G -smp 4 $ACCEL -device qemu-xhci,id=xhci -device usb-tablet,bus=xhci.0 -drive file=/opt/bytebot-lubuntu-22.04.5.qcow2,format=qcow2 -vnc 0.0.0.0:0,websocket=6080 -boot c -qmp unix:/tmp/qmp-sock,server,nowait'
+command=sh -c 'if [ "$(uname)" = "Darwin" ] && [ -d "/Library/Apple/System/Library/Frameworks/Hypervisor.framework" ]; then ACCEL="-accel hvf"; elif [ -e /dev/kvm ]; then ACCEL="-accel kvm"; else ACCEL="-accel tcg"; fi; echo "Starting QEMU with VNC on port 5900 and no websocket"; qemu-system-x86_64 -m 8G -smp 4 $ACCEL -device qemu-xhci,id=xhci -device usb-tablet,bus=xhci.0 -drive file=/opt/bytebot-lubuntu-22.04.5.qcow2,format=qcow2 -vnc 0.0.0.0:0 -boot c -qmp unix:/tmp/qmp-sock,server,nowait; echo "QEMU exited with status $?"'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:hypervisor]
-; Wait until port 6080 is open, then start the hypervisor.
-command=sh -c 'while ! nc -z localhost 6080; do echo "Waiting for port 6080 to open..."; sleep 1; done; exec node /hypervisor/dist/main.js'
+; Start the hypervisor after waiting for the VM to boot up
+command=sh -c 'echo "Waiting for QEMU VM to boot up and VNC to be available..."; while ! nc -z localhost 5900; do echo "Waiting for VNC port 5900..."; sleep 2; done; echo "VNC port is available, starting hypervisor"; exec node /hypervisor/dist/main.js'
 directory=/hypervisor
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:novnc-http]
-; Serve the noVNC client files using BusyBox's HTTP server on port 6081.
-; Wait until port 6080 is open before starting.
-command=sh -c 'while ! nc -z localhost 6080; do echo "Waiting for port 6080 to open..."; sleep 1; done; exec python3 -m http.server 6081 --directory /opt/noVNC'
+; Serve the noVNC client files using Python's HTTP server on port 6081.
+; Start without waiting for port 6080
+command=sh -c 'echo "Starting noVNC HTTP server on port 6081 without waiting for port 6080"; sleep 5; echo "Network ports:"; netstat -tuln; exec python3 -m http.server 6081 --directory /opt/noVNC'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true
+
+[program:websockify]
+; Run websockify to proxy VNC traffic from WebSocket to TCP
+command=sh -c 'echo "Starting websockify to proxy from port 6080 to VNC port 5900"; sleep 5; websockify 6080 localhost:5900'
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
The current version isn't working in Orbstack due to a few networking issues. This pulls the websocket out from qemu and uses websockify instead to proxy the socket. 

Logs:
```
2025-03-05 03:18:47,254 INFO Set uid to user 0 succeeded
2025-03-05 03:18:47,254 INFO Set uid to user 0 succeeded
2025-03-05 03:18:47,257 INFO supervisord started with pid 1
2025-03-05 03:18:47,257 INFO supervisord started with pid 1
2025-03-05 03:18:48,268 INFO spawned: 'desktop-vm' with pid 7
2025-03-05 03:18:48,268 INFO spawned: 'desktop-vm' with pid 7
2025-03-05 03:18:48,277 INFO spawned: 'hypervisor' with pid 8
2025-03-05 03:18:48,277 INFO spawned: 'hypervisor' with pid 8
2025-03-05 03:18:48,286 INFO spawned: 'novnc-http' with pid 9
2025-03-05 03:18:48,286 INFO spawned: 'novnc-http' with pid 9
2025-03-05 03:18:48,291 INFO spawned: 'websockify' with pid 12
2025-03-05 03:18:48,291 INFO spawned: 'websockify' with pid 12
Starting QEMU with VNC on port 5900
Waiting for websockify on port 6080 (hypervisor)...
Waiting for websockify on port 6080 (noVNC)...
Starting websockify to proxy from port 6080 to VNC port 5900
2025-03-05 03:18:49,302 INFO success: desktop-vm entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-05 03:18:49,302 INFO success: desktop-vm entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-05 03:18:49,302 INFO success: hypervisor entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-05 03:18:49,302 INFO success: hypervisor entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-05 03:18:49,302 INFO success: novnc-http entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-05 03:18:49,302 INFO success: novnc-http entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-05 03:18:49,302 INFO success: websockify entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-03-05 03:18:49,302 INFO success: websockify entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
WebSocket server settings:
  - Listen on :6080
  - No SSL/TLS support (no cert file)
  - proxying from :6080 to localhost:5900
Connection to localhostConnection to localhost (127.0.0.1) 6080 port [tcp/*] succeeded!
Websockify is ready, starting noVNC HTTP server on port 6081
 (127.0.0.1) 6080 port [tcp/*] succeeded!
Websockify is ready, starting hypervisor
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [NestFactory] Starting Nest application...
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [InstanceLoader] QemuModule dependencies initialized +8ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [InstanceLoader] AppModule dependencies initialized +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [InstanceLoader] ComputerUseModule dependencies initialized +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RoutesResolver] AppController {/}: +3ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/vnc, GET} route +1ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RoutesResolver] ComputerUseController {/computer-use}: +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/key, POST} route +1ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/type, POST} route +1ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/mouse-move, POST} route +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/left-click, POST} route +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/left-click-drag, POST} route +1ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/right-click, POST} route +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/middle-click, POST} route +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/double-click, POST} route +1ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/scroll, POST} route +0ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/screenshot, GET} route +2ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [RouterExplorer] Mapped {/computer-use/cursor-position, GET} route +2ms
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [QmpClientService] Connected to QEMU QMP socket.
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [QmpClientService] QMP capabilities enabled.
[Nest] 8  - 03/05/2025, 3:18:54 AM     LOG [NestApplication] Nest application successfully started +1ms
```