### PR TITLE
Fix: Support ARM architecture by removing platform flag

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -66,7 +66,7 @@ fi
     echo "Running Bytebot with tag: $TAG"
 
     # Run the container
-    docker run --privileged -d --platform linux/amd64 \
+    docker run --privileged -d \
         -p 9990:9990 -p 5900:5900 -p 6080:6080 -p 6081:6081 \
         --name "bytebot-$TAG" \
         "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
When running Bytebot on ARM architecture (M1/M2/M3 Mac, etc.), the `docker image inspect` command succeeds, but `docker run` fails with an "image not found" error.

## Root Cause
The `--platform linux/amd64` flag in `scripts/run.sh` causes Docker's internal image lookup logic to malfunction on ARM environments, resulting in the container failing to start despite the image being present.

## Fix
This PR removes the `--platform linux/amd64` flag from the `docker run` command. As a result:
1. On ARM environments, Docker will display a platform mismatch warning but successfully run the container using its emulation capabilities
2. On x86/AMD64 environments, the container continues to work as before

## Testing
- Verified container starts successfully on ARM environment (Apple Silicon Mac)
- Tested with Docker Desktop 4.27.1