### PR TITLE
Enable input tracking toggle

### DIFF
--- a/docs/rest-api/input-tracking.mdx
+++ b/docs/rest-api/input-tracking.mdx
@@ -1,0 +1,41 @@
+---
+title: "Input Tracking"
+openapi: "POST /input-tracking/start"
+description: "Start and stop input tracking on the Bytebot desktop"
+---
+
+The Bytebot daemon can monitor mouse and keyboard events through the
+`InputTracking` module. Tracking is disabled by default and can be toggled
+via the REST API. Tracked actions are streamed over WebSockets so that the
+agent can store them as messages.
+
+## Start Tracking
+
+`POST /input-tracking/start`
+
+Begins capturing input events. The endpoint returns a simple status object:
+
+```json
+{
+  "status": "started"
+}
+```
+
+## Stop Tracking
+
+`POST /input-tracking/stop`
+
+Stops capturing events and clears any internal buffers. The response is
+similar to the start endpoint:
+
+```json
+{
+  "status": "stopped"
+}
+```
+
+## WebSocket Stream
+
+When tracking is active, actions are emitted on the `input_action` channel of
+the WebSocket server running on the daemon. Clients can connect to the daemon
+and listen for these events to persist them as needed.

--- a/docs/rest-api/introduction.mdx
+++ b/docs/rest-api/introduction.mdx
@@ -64,6 +64,9 @@ Common HTTP status codes:
     Execute desktop automation actions like mouse movements, clicks, keyboard
     input, and screenshots
   </Card>
+  <Card title="Input Tracking" icon="eye" href="/rest-api/input-tracking">
+    Control and stream keyboard and mouse events from the desktop
+  </Card>
   <Card title="Usage Examples" icon="code" href="/rest-api/examples">
     Code examples and snippets for common automation scenarios
   </Card>

--- a/packages/bytebot-agent/package-lock.json
+++ b/packages/bytebot-agent/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
+        "@nestjs/event-emitter": "^3.0.1",
         "@nestjs/platform-express": "^11.1.2",
         "@nestjs/platform-socket.io": "^11.1.1",
         "@nestjs/schedule": "^6.0.0",
@@ -2611,6 +2612,19 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.0.1.tgz",
+      "integrity": "sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/platform-express": {
@@ -6596,6 +6610,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",

--- a/packages/bytebot-agent/package-lock.json
+++ b/packages/bytebot-agent/package-lock.json
@@ -22,7 +22,8 @@
         "class-validator": "^0.14.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
-        "socket.io": "^4.8.1"
+        "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -6167,6 +6168,36 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -10579,6 +10610,38 @@
         }
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -12267,6 +12330,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -35,7 +35,8 @@
     "class-validator": "^0.14.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -27,6 +27,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/platform-express": "^11.1.2",
     "@nestjs/platform-socket.io": "^11.1.1",
     "@nestjs/schedule": "^6.0.0",

--- a/packages/bytebot-agent/src/agent/agent.module.ts
+++ b/packages/bytebot-agent/src/agent/agent.module.ts
@@ -5,10 +5,11 @@ import { AnthropicModule } from '../anthropic/anthropic.module';
 import { AgentProcessor } from './agent.processor';
 import { ConfigModule } from '@nestjs/config';
 import { AgentScheduler } from './agent.scheduler';
+import { InputCaptureService } from './input-capture.service';
 
 @Module({
   imports: [ConfigModule, TasksModule, MessagesModule, AnthropicModule],
-  providers: [AgentProcessor, AgentScheduler],
+  providers: [AgentProcessor, AgentScheduler, InputCaptureService],
   exports: [AgentProcessor],
 })
 export class AgentModule {}

--- a/packages/bytebot-agent/src/agent/agent.processor.ts
+++ b/packages/bytebot-agent/src/agent/agent.processor.ts
@@ -19,21 +19,16 @@ import {
   isPressKeysToolUseBlock,
   isSetTaskStatusToolUseBlock,
   isCreateTaskToolUseBlock,
-  isMoveMouseAction,
   convertMoveMouseActionToToolUseBlock,
-  isTraceMouseAction,
-  isClickMouseAction,
-  isPressMouseAction,
-  isTypeKeysAction,
-  isTypeTextAction,
   convertTraceMouseActionToToolUseBlock,
   convertClickMouseActionToToolUseBlock,
   convertPressMouseActionToToolUseBlock,
-  convertTypeKeysActionToToolUseBlock,
   convertTypeTextActionToToolUseBlock,
   convertDragMouseActionToToolUseBlock,
   convertScrollActionToToolUseBlock,
   ScreenshotToolUseBlock,
+  convertPressKeysActionToToolUseBlock,
+  convertTypeKeysActionToToolUseBlock,
 } from '@bytebot/shared';
 
 import {
@@ -885,19 +880,6 @@ export class AgentProcessor {
         };
 
         switch (action.action) {
-          case 'move_mouse':
-            content.push(
-              convertMoveMouseActionToToolUseBlock(action, toolUseId),
-              toolResult,
-            );
-
-            break;
-          case 'trace_mouse':
-            content.push(
-              convertTraceMouseActionToToolUseBlock(action, toolUseId),
-              toolResult,
-            );
-            break;
           case 'drag_mouse':
             content.push(
               convertDragMouseActionToToolUseBlock(action, toolUseId),
@@ -920,6 +902,12 @@ export class AgentProcessor {
           case 'type_keys':
             content.push(
               convertTypeKeysActionToToolUseBlock(action, toolUseId),
+              toolResult,
+            );
+            break;
+          case 'press_keys':
+            content.push(
+              convertPressKeysActionToToolUseBlock(action, toolUseId),
               toolResult,
             );
             break;

--- a/packages/bytebot-agent/src/agent/agent.scheduler.ts
+++ b/packages/bytebot-agent/src/agent/agent.scheduler.ts
@@ -44,7 +44,7 @@ export class AgentScheduler implements OnModuleInit {
         executedAt: new Date(),
       });
       this.logger.debug(`Processing task ID: ${task.id}`);
-      await this.agentProcessor.processTask(task.id);
+      this.agentProcessor.processTask(task.id);
     }
   }
 }

--- a/packages/bytebot-agent/src/agent/input-capture.service.ts
+++ b/packages/bytebot-agent/src/agent/input-capture.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { io, Socket } from 'socket.io-client';
+import { randomUUID } from 'crypto';
+import {
+  convertClickMouseActionToToolUseBlock,
+  convertDragMouseActionToToolUseBlock,
+  convertPressKeysActionToToolUseBlock,
+  convertPressMouseActionToToolUseBlock,
+  convertScrollActionToToolUseBlock,
+  convertTypeKeysActionToToolUseBlock,
+  convertTypeTextActionToToolUseBlock,
+  MessageContentBlock,
+  MessageContentType,
+  ScreenshotToolUseBlock,
+  ToolResultContentBlock,
+} from '@bytebot/shared';
+import { Role } from '@prisma/client';
+import { MessagesService } from '../messages/messages.service';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class InputCaptureService {
+  private readonly logger = new Logger(InputCaptureService.name);
+  private socket: Socket | null = null;
+  private capturing = false;
+
+  constructor(
+    private readonly messagesService: MessagesService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  isCapturing() {
+    return this.capturing;
+  }
+
+  start(taskId: string) {
+    if (this.socket?.connected && this.capturing) return;
+
+    if (this.socket && !this.socket.connected) {
+      this.socket.connect();
+      return;
+    }
+
+    const baseUrl = this.configService.get<string>('BYTEBOT_DESKTOP_BASE_URL');
+    if (!baseUrl) {
+      this.logger.warn('BYTEBOT_DESKTOP_BASE_URL missing.');
+      return;
+    }
+
+    this.socket = io(baseUrl, { transports: ['websocket'] });
+
+    this.socket.on('connect', () => {
+      this.logger.log('Input socket connected');
+      this.capturing = true;
+    });
+
+    this.socket.on('screenshot', async (shot: { image: string }) => {
+      if (!this.capturing || !taskId) return;
+      const toolUseId = randomUUID();
+      const screenshotBlock: ScreenshotToolUseBlock = {
+        type: MessageContentType.ToolUse,
+        name: 'computer_screenshot',
+        id: toolUseId,
+        input: {},
+      };
+      const toolResult: ToolResultContentBlock = {
+        type: MessageContentType.ToolResult,
+        tool_use_id: toolUseId,
+        content: [
+          {
+            type: MessageContentType.Image,
+            source: { data: shot.image, media_type: 'image/png', type: 'base64' },
+          },
+        ],
+      };
+      await this.messagesService.create({
+        content: [screenshotBlock, toolResult],
+        role: Role.USER,
+        taskId,
+      });
+    });
+
+    this.socket.on('input_action', async (action: any) => {
+      if (!this.capturing || !taskId) return;
+      const toolUseId = randomUUID();
+      const blocks: MessageContentBlock[] = [];
+      const toolResult: ToolResultContentBlock = {
+        type: MessageContentType.ToolResult,
+        tool_use_id: toolUseId,
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Input action '${action.action}' processed.`,
+          },
+        ],
+      };
+
+      switch (action.action) {
+        case 'drag_mouse':
+          blocks.push(convertDragMouseActionToToolUseBlock(action, toolUseId), toolResult);
+          break;
+        case 'click_mouse':
+          blocks.push(convertClickMouseActionToToolUseBlock(action, toolUseId), toolResult);
+          break;
+        case 'press_mouse':
+          blocks.push(convertPressMouseActionToToolUseBlock(action, toolUseId), toolResult);
+          break;
+        case 'type_keys':
+          blocks.push(convertTypeKeysActionToToolUseBlock(action, toolUseId), toolResult);
+          break;
+        case 'press_keys':
+          blocks.push(convertPressKeysActionToToolUseBlock(action, toolUseId), toolResult);
+          break;
+        case 'type_text':
+          blocks.push(convertTypeTextActionToToolUseBlock(action, toolUseId), toolResult);
+          break;
+        case 'scroll':
+          blocks.push(convertScrollActionToToolUseBlock(action, toolUseId), toolResult);
+          break;
+        default:
+          this.logger.warn(`Unknown action ${action.action}`);
+      }
+
+      if (blocks.length) {
+        await this.messagesService.create({ content: blocks, role: Role.USER, taskId });
+      }
+    });
+
+    this.socket.on('disconnect', () => {
+      this.logger.log('Input socket disconnected');
+      this.capturing = false;
+    });
+  }
+
+  async stop() {
+    if (!this.socket) return;
+    if (this.socket.connected) this.socket.disconnect();
+    else this.socket.removeAllListeners();
+    this.socket = null;
+    this.capturing = false;
+  }
+}

--- a/packages/bytebot-agent/src/app.module.ts
+++ b/packages/bytebot-agent/src/app.module.ts
@@ -8,10 +8,12 @@ import { AnthropicModule } from './anthropic/anthropic.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot(),
     ConfigModule.forRoot({
       isGlobal: true,
     }),

--- a/packages/bytebot-agent/src/tasks/tasks.controller.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.ts
@@ -73,4 +73,10 @@ export class TasksController {
   async takeOver(@Param('id') taskId: string): Promise<Task> {
     return this.tasksService.takeOver(taskId);
   }
+
+  @Post(':id/resume')
+  @HttpCode(HttpStatus.OK)
+  async resume(@Param('id') taskId: string): Promise<Task> {
+    return this.tasksService.resume(taskId);
+  }
 }

--- a/packages/bytebot-agent/src/tasks/tasks.service.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.service.ts
@@ -21,6 +21,7 @@ import {
 import { GuideTaskDto } from './dto/guide-task.dto';
 import { TasksGateway } from './tasks.gateway';
 import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class TasksService {
@@ -31,6 +32,7 @@ export class TasksService {
     @Inject(forwardRef(() => TasksGateway))
     private readonly tasksGateway: TasksGateway,
     private readonly configService: ConfigService,
+    private readonly eventEmitter: EventEmitter2,
   ) {
     this.logger.log('TasksService initialized');
   }
@@ -200,15 +202,14 @@ export class TasksService {
   }
 
   async guideTask(taskId: string, guideTaskDto: GuideTaskDto) {
-    let task = await this.findById(taskId);
+    const task = await this.findById(taskId);
     if (!task) {
       this.logger.warn(`Task with ID: ${taskId} not found for guiding`);
       throw new NotFoundException(`Task with ID ${taskId} not found`);
     }
 
-    // Allow guiding for NEEDS_HELP status or during takeover
-    const canGuide =
-      task.status === TaskStatus.NEEDS_HELP || task.control !== Role.ASSISTANT;
+    // Allow guiding for NEEDS_HELP status
+    const canGuide = task.status === TaskStatus.NEEDS_HELP;
 
     if (!canGuide) {
       this.logger.warn(
@@ -229,35 +230,51 @@ export class TasksService {
 
     this.tasksGateway.emitNewMessage(taskId, message);
 
-    const wasUserControl = task.control !== Role.ASSISTANT;
+    const updatedTask = await this.prisma.task.update({
+      where: { id: taskId },
+      data: {
+        status: TaskStatus.RUNNING,
+      },
+    });
 
-    if (wasUserControl) {
-      try {
-        await fetch(
-          `${this.configService.get<string>('BYTEBOT_DESKTOP_BASE_URL')}/input-tracking/stop`,
-          { method: 'POST' },
-        );
-      } catch (error) {
-        this.logger.error('Failed to stop input tracking', error as any);
-      }
+    return updatedTask;
+  }
+
+  async resume(taskId: string): Promise<Task> {
+    this.logger.log(`Resuming task ID: ${taskId}`);
+
+    const task = await this.findById(taskId);
+    if (!task) {
+      throw new NotFoundException(`Task with ID ${taskId} not found`);
     }
 
-    const updateData: any = {};
-    if (task.status === TaskStatus.NEEDS_HELP) {
-      updateData.status = TaskStatus.RUNNING;
+    if (task.control !== Role.USER) {
+      throw new BadRequestException(`Task ${taskId} is not under user control`);
     }
-    if (task.control !== Role.ASSISTANT) {
-      updateData.control = Role.ASSISTANT;
-      this.logger.log(
-        `Task ${taskId} control automatically resumed after user message`,
+
+    const updatedTask = await this.prisma.task.update({
+      where: { id: taskId },
+      data: {
+        control: Role.ASSISTANT,
+      },
+    });
+
+    try {
+      await fetch(
+        `${this.configService.get<string>('BYTEBOT_DESKTOP_BASE_URL')}/input-tracking/stop`,
+        { method: 'POST' },
       );
+    } catch (error) {
+      this.logger.error('Failed to stop input tracking', error as any);
     }
 
-    if (Object.keys(updateData).length > 0) {
-      await this.update(taskId, updateData);
-    }
+    // Broadcast resume event so AgentProcessor can react
+    this.eventEmitter.emit('task.resume', { taskId });
 
-    return task;
+    this.logger.log(`Task ${taskId} resumed`);
+    this.tasksGateway.emitTaskUpdate(taskId, updatedTask);
+
+    return updatedTask;
   }
 
   async takeOver(taskId: string): Promise<Task> {
@@ -289,6 +306,9 @@ export class TasksService {
     } catch (error) {
       this.logger.error('Failed to start input tracking', error as any);
     }
+
+    // Broadcast takeover event so AgentProcessor can react
+    this.eventEmitter.emit('task.takeover', { taskId });
 
     this.logger.log(`Task ${taskId} takeover initiated`);
     this.tasksGateway.emitTaskUpdate(taskId, updatedTask);

--- a/packages/bytebot-agent/src/tasks/tasks.service.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.service.ts
@@ -99,7 +99,6 @@ export class TasksService {
         status: {
           in: [TaskStatus.RUNNING, TaskStatus.PENDING],
         },
-        control: Role.ASSISTANT,
       },
       orderBy: [
         { executedAt: 'asc' },

--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -35,7 +35,8 @@ export default function TaskPage() {
     isLoading,
     isLoadingSession,
     handleGuideTask,
-    handleTakeOver,
+    handleTakeOverTask,
+    handleResumeTask,
     currentTaskId,
   } = useChatSession({ initialTaskId: taskId });
 
@@ -49,8 +50,7 @@ export default function TaskPage() {
 
   // Determine if user can take control
   const canTakeOver =
-    control === Role.ASSISTANT &&
-    (taskStatus === TaskStatus.RUNNING || taskStatus === TaskStatus.PENDING);
+    control === Role.ASSISTANT && taskStatus === TaskStatus.RUNNING;
 
   // Determine if user has control or is in takeover mode
   const hasUserControl =
@@ -158,10 +158,18 @@ export default function TaskPage() {
                 <div className="flex items-center gap-2">
                   {canTakeOver && (
                     <button
-                      onClick={handleTakeOver}
+                      onClick={handleTakeOverTask}
                       className="cursor-pointer rounded bg-gray-500 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-gray-600"
                     >
                       Take Over
+                    </button>
+                  )}
+                  {hasUserControl && (
+                    <button
+                      onClick={handleResumeTask}
+                      className="cursor-pointer rounded bg-gray-500 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-gray-600"
+                    >
+                      Resume
                     </button>
                   )}
                   {isTaskInactive && currentScreenshot && (
@@ -211,7 +219,7 @@ export default function TaskPage() {
             </div>
 
             {/* Fixed chat input */}
-            {(taskStatus === TaskStatus.NEEDS_HELP || hasUserControl) && (
+            {taskStatus === TaskStatus.NEEDS_HELP && (
               <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-5 shadow-bytebot rounded-2xl border-[0.5px] p-2">
                 <ChatInput
                   input={input}
@@ -219,11 +227,6 @@ export default function TaskPage() {
                   onInputChange={setInput}
                   onSend={handleGuideTask}
                   minLines={1}
-                  placeholder={
-                    hasUserControl
-                      ? "Send a message to resume agent control..."
-                      : ""
-                  }
                 />
                 <div className="mt-2">
                   <Select value="sonnet-4">

--- a/packages/bytebot-ui/src/components/messages/MessageGroup.tsx
+++ b/packages/bytebot-ui/src/components/messages/MessageGroup.tsx
@@ -338,6 +338,84 @@ export function UserMessage({ group, messages = [] }: MessageGroupProps) {
                   {isTextContentBlock(block) && (
                     <ReactMarkdown>{block.text}</ReactMarkdown>
                   )}
+                  {isComputerToolUseContentBlock(block) && (
+                    <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-7 shadow-bytebot max-w-4/5 rounded-md border px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <HugeiconsIcon
+                          icon={getIcon(block)}
+                          className="text-bytebot-bronze-dark-9 h-4 w-4"
+                        />
+                        <p className="text-bytebot-bronze-light-11 text-xs">
+                          {getLabel(block)}
+                        </p>
+                        {/* Text for type and key actions */}
+                        {(isTypeKeysToolUseBlock(block) ||
+                          isPressKeysToolUseBlock(block)) && (
+                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
+                            {String(block.input.keys.join("+"))}
+                          </p>
+                        )}
+                        {isTypeTextToolUseBlock(block) && (
+                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
+                            {String(
+                              block.input.isSensitive
+                                ? "●".repeat(block.input.text.length)
+                                : block.input.text,
+                            )}
+                          </p>
+                        )}
+                        {/* Duration for wait and hold_key actions */}
+                        {isWaitToolUseBlock(block) && (
+                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
+                            {`${block.input.duration}ms`}
+                          </p>
+                        )}
+                        {/* Coordinates for click/mouse actions */}
+                        {block.input.coordinates && (
+                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
+                            {
+                              (
+                                block.input.coordinates as {
+                                  x: number;
+                                  y: number;
+                                }
+                              ).x
+                            }
+                            ,{" "}
+                            {
+                              (
+                                block.input.coordinates as {
+                                  x: number;
+                                  y: number;
+                                }
+                              ).y
+                            }
+                          </p>
+                        )}
+                        {/* Start and end coordinates for path actions */}
+                        {"path" in block.input &&
+                          Array.isArray(block.input.path) &&
+                          block.input.path.every(
+                            (point) =>
+                              point.x !== undefined && point.y !== undefined,
+                          ) && (
+                            <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
+                              From: {block.input.path[0].x},{" "}
+                              {block.input.path[0].y} → To:{" "}
+                              {block.input.path[block.input.path.length - 1].x},{" "}
+                              {block.input.path[block.input.path.length - 1].y}
+                            </p>
+                          )}
+                        {/* Scroll information */}
+                        {isScrollToolUseBlock(block) && (
+                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
+                            {String(block.input.direction)}{" "}
+                            {Number(block.input.numScrolls)}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/packages/bytebot-ui/src/components/messages/MessageGroup.tsx
+++ b/packages/bytebot-ui/src/components/messages/MessageGroup.tsx
@@ -339,81 +339,79 @@ export function UserMessage({ group, messages = [] }: MessageGroupProps) {
                     <ReactMarkdown>{block.text}</ReactMarkdown>
                   )}
                   {isComputerToolUseContentBlock(block) && (
-                    <div className="bg-bytebot-bronze-light-2 border-bytebot-bronze-light-7 shadow-bytebot max-w-4/5 rounded-md border px-3 py-2">
-                      <div className="flex items-center gap-2">
-                        <HugeiconsIcon
-                          icon={getIcon(block)}
-                          className="text-bytebot-bronze-dark-9 h-4 w-4"
-                        />
-                        <p className="text-bytebot-bronze-light-11 text-xs">
-                          {getLabel(block)}
+                    <div className="flex items-center gap-2">
+                      <HugeiconsIcon
+                        icon={getIcon(block)}
+                        className="h-4 w-4 text-fuchsia-600"
+                      />
+                      <p className="text-xs text-fuchsia-600">
+                        {getLabel(block)}
+                      </p>
+                      {/* Text for type and key actions */}
+                      {(isTypeKeysToolUseBlock(block) ||
+                        isPressKeysToolUseBlock(block)) && (
+                        <p className="bg-bytebot-bronze-light-1 rounded-md border border-fuchsia-600 px-1 py-0.5 text-xs text-fuchsia-600">
+                          {String(block.input.keys.join("+"))}
                         </p>
-                        {/* Text for type and key actions */}
-                        {(isTypeKeysToolUseBlock(block) ||
-                          isPressKeysToolUseBlock(block)) && (
-                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
-                            {String(block.input.keys.join("+"))}
-                          </p>
-                        )}
-                        {isTypeTextToolUseBlock(block) && (
-                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
-                            {String(
-                              block.input.isSensitive
-                                ? "●".repeat(block.input.text.length)
-                                : block.input.text,
-                            )}
-                          </p>
-                        )}
-                        {/* Duration for wait and hold_key actions */}
-                        {isWaitToolUseBlock(block) && (
-                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
-                            {`${block.input.duration}ms`}
-                          </p>
-                        )}
-                        {/* Coordinates for click/mouse actions */}
-                        {block.input.coordinates && (
-                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
-                            {
-                              (
-                                block.input.coordinates as {
-                                  x: number;
-                                  y: number;
-                                }
-                              ).x
-                            }
-                            ,{" "}
-                            {
-                              (
-                                block.input.coordinates as {
-                                  x: number;
-                                  y: number;
-                                }
-                              ).y
-                            }
-                          </p>
-                        )}
-                        {/* Start and end coordinates for path actions */}
-                        {"path" in block.input &&
-                          Array.isArray(block.input.path) &&
-                          block.input.path.every(
-                            (point) =>
-                              point.x !== undefined && point.y !== undefined,
-                          ) && (
-                            <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
-                              From: {block.input.path[0].x},{" "}
-                              {block.input.path[0].y} → To:{" "}
-                              {block.input.path[block.input.path.length - 1].x},{" "}
-                              {block.input.path[block.input.path.length - 1].y}
-                            </p>
+                      )}
+                      {isTypeTextToolUseBlock(block) && (
+                        <p className="bg-bytebot-bronze-light-1 rounded-md border border-fuchsia-600 px-1 py-0.5 text-xs text-fuchsia-600">
+                          {String(
+                            block.input.isSensitive
+                              ? "●".repeat(block.input.text.length)
+                              : block.input.text,
                           )}
-                        {/* Scroll information */}
-                        {isScrollToolUseBlock(block) && (
-                          <p className="bg-bytebot-bronze-light-1 border-bytebot-bronze-light-7 text-bytebot-bronze-light-11 rounded-md border px-1 py-0.5 text-xs">
-                            {String(block.input.direction)}{" "}
-                            {Number(block.input.numScrolls)}
+                        </p>
+                      )}
+                      {/* Duration for wait and hold_key actions */}
+                      {isWaitToolUseBlock(block) && (
+                        <p className="bg-bytebot-bronze-light-1 rounded-md border border-fuchsia-600 px-1 py-0.5 text-xs text-fuchsia-600">
+                          {`${block.input.duration}ms`}
+                        </p>
+                      )}
+                      {/* Coordinates for click/mouse actions */}
+                      {block.input.coordinates && (
+                        <p className="bg-bytebot-bronze-light-1 rounded-md border border-fuchsia-600 px-1 py-0.5 text-xs text-fuchsia-600">
+                          {
+                            (
+                              block.input.coordinates as {
+                                x: number;
+                                y: number;
+                              }
+                            ).x
+                          }
+                          ,{" "}
+                          {
+                            (
+                              block.input.coordinates as {
+                                x: number;
+                                y: number;
+                              }
+                            ).y
+                          }
+                        </p>
+                      )}
+                      {/* Start and end coordinates for path actions */}
+                      {"path" in block.input &&
+                        Array.isArray(block.input.path) &&
+                        block.input.path.every(
+                          (point) =>
+                            point.x !== undefined && point.y !== undefined,
+                        ) && (
+                          <p className="bg-bytebot-bronze-light-1 rounded-md border border-fuchsia-600 px-1 py-0.5 text-xs text-fuchsia-600">
+                            From: {block.input.path[0].x},{" "}
+                            {block.input.path[0].y} → To:{" "}
+                            {block.input.path[block.input.path.length - 1].x},{" "}
+                            {block.input.path[block.input.path.length - 1].y}
                           </p>
                         )}
-                      </div>
+                      {/* Scroll information */}
+                      {isScrollToolUseBlock(block) && (
+                        <p className="bg-bytebot-bronze-light-1 rounded-md border border-fuchsia-600 px-1 py-0.5 text-xs text-fuchsia-600">
+                          {String(block.input.direction)}{" "}
+                          {Number(block.input.numScrolls)}
+                        </p>
+                      )}
                     </div>
                   )}
                 </div>

--- a/packages/bytebot-ui/src/utils/taskUtils.ts
+++ b/packages/bytebot-ui/src/utils/taskUtils.ts
@@ -160,3 +160,26 @@ export async function takeOverTask(taskId: string): Promise<Task | null> {
     return null;
   }
 }
+
+export async function resumeTask(taskId: string): Promise<Task | null> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BYTEBOT_AGENT_BASE_URL}/tasks/${taskId}/resume`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error("Failed to resume task");
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Error resuming task:", error);
+    return null;
+  }
+}

--- a/packages/bytebotd/package-lock.json
+++ b/packages/bytebotd/package-lock.json
@@ -13,11 +13,14 @@
         "@nestjs/config": "^4.0.1",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.1.2",
+        "@nestjs/platform-socket.io": "^11.1.2",
+        "@nestjs/websockets": "^11.1.2",
         "@nut-tree-fork/nut-js": "^4.2.6",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "socket.io": "^4.8.1",
         "uiohook-napi": "^1.5.4"
       },
       "devDependencies": {
@@ -2684,6 +2687,25 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.2.tgz",
+      "integrity": "sha512-IkeDPRRddY0In6lE+5H/DJodtF5cEx+ga+GWehs4Il5Y3kK7MVR2/WgUABAhyRsbJYOhIhZD7Dai0V2t9ref1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.2.tgz",
@@ -2806,6 +2828,29 @@
           "optional": true
         },
         "@nestjs/platform-express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.2.tgz",
+      "integrity": "sha512-Ywl7u0C3+qnKIrk0mD3jHWnowO+GScFT1FeP6cNgarA0ujHEfusph9IIbnUJiEiusfnKVpK9fYMGZRSDwnRGPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-socket.io": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
           "optional": true
         }
       }
@@ -3077,6 +3122,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@swc/cli": {
       "version": "0.6.0",
@@ -3360,6 +3411,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.18.tgz",
+      "integrity": "sha512-nX3d0sxJW41CqQvfOzVG1NCTXfFDrDWIghCZncpHeWlVFd81zxB/DLhg7avFg6eHLCRX7ckBmoIIcqa++upvJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -3501,7 +3561,6 @@
       "version": "22.13.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
       "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -4601,6 +4660,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/bin-version": {
       "version": "6.0.0",
@@ -5898,6 +5966,95 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9256,6 +9413,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -10651,6 +10817,141 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -11753,7 +12054,6 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -12251,6 +12551,27 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xhr": {
       "version": "2.6.0",

--- a/packages/bytebotd/package.json
+++ b/packages/bytebotd/package.json
@@ -30,11 +30,14 @@
     "@nestjs/config": "^4.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.1.2",
+    "@nestjs/platform-socket.io": "^11.1.2",
+    "@nestjs/websockets": "^11.1.2",
     "@nut-tree-fork/nut-js": "^4.2.6",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "socket.io": "^4.8.1",
     "uiohook-napi": "^1.5.4"
   },
   "devDependencies": {

--- a/packages/bytebotd/src/computer-use/computer-use.service.ts
+++ b/packages/bytebotd/src/computer-use/computer-use.service.ts
@@ -22,7 +22,7 @@ export type ClickMouseAction = {
   coordinates?: Coordinates;
   button: Button;
   holdKeys?: string[];
-  numClicks?: number;
+  numClicks: number;
 };
 
 export type PressMouseAction = {
@@ -198,7 +198,7 @@ export class ComputerUseService {
     }
 
     // Perform clicks
-    if (numClicks && numClicks > 1) {
+    if (numClicks > 1) {
       // Perform multiple clicks
       for (let i = 0; i < numClicks; i++) {
         await this.nutService.mouseClickEvent(button);
@@ -299,7 +299,7 @@ export class ComputerUseService {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  private async screenshot(): Promise<{ image: string }> {
+  async screenshot(): Promise<{ image: string }> {
     this.logger.log(`Taking screenshot`);
     const buffer = await this.nutService.screendump();
     return { image: `${buffer.toString('base64')}` };

--- a/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
+++ b/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
@@ -57,10 +57,9 @@ export class ClickMouseActionDto {
   @IsString({ each: true })
   holdKeys?: string[];
 
-  @IsOptional()
   @IsNumber()
   @Min(1)
-  numClicks?: number;
+  numClicks: number;
 }
 
 export class PressMouseActionDto {

--- a/packages/bytebotd/src/input-tracking/input-tracking.controller.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Post } from '@nestjs/common';
+import { InputTrackingService } from './input-tracking.service';
+
+@Controller('input-tracking')
+export class InputTrackingController {
+  constructor(private readonly inputTrackingService: InputTrackingService) {}
+
+  @Post('start')
+  start() {
+    this.inputTrackingService.startTracking();
+    return { status: 'started' };
+  }
+
+  @Post('stop')
+  stop() {
+    this.inputTrackingService.stopTracking();
+    return { status: 'stopped' };
+  }
+
+}

--- a/packages/bytebotd/src/input-tracking/input-tracking.gateway.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.gateway.ts
@@ -32,10 +32,13 @@ export class InputTrackingGateway
   }
 
   emitAction(action: ComputerAction) {
-    this.server.emit('input_action', action);
+    this.server.emit('action', action);
   }
 
-  emitScreenshot(screenshot: { image: string }) {
-    this.server.emit('screenshot', screenshot);
+  emitScreenshotAndAction(
+    screenshot: { image: string },
+    action: ComputerAction,
+  ) {
+    this.server.emit('screenshotAndAction', screenshot, action);
   }
 }

--- a/packages/bytebotd/src/input-tracking/input-tracking.gateway.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.gateway.ts
@@ -1,0 +1,37 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { Injectable, Logger } from '@nestjs/common';
+import { ComputerAction } from '../computer-use/computer-use.service';
+
+@Injectable()
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+})
+export class InputTrackingGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  private readonly logger = new Logger(InputTrackingGateway.name);
+
+  @WebSocketServer()
+  server: Server;
+
+  handleConnection(client: Socket) {
+    this.logger.log(`Client connected: ${client.id}`);
+  }
+
+  handleDisconnect(client: Socket) {
+    this.logger.log(`Client disconnected: ${client.id}`);
+  }
+
+  emitAction(action: ComputerAction) {
+    this.server.emit('input_action', action);
+  }
+}

--- a/packages/bytebotd/src/input-tracking/input-tracking.gateway.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.gateway.ts
@@ -34,4 +34,8 @@ export class InputTrackingGateway
   emitAction(action: ComputerAction) {
     this.server.emit('input_action', action);
   }
+
+  emitScreenshot(screenshot: { image: string }) {
+    this.server.emit('screenshot', screenshot);
+  }
 }

--- a/packages/bytebotd/src/input-tracking/input-tracking.helpers.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.helpers.ts
@@ -1,0 +1,646 @@
+import { UiohookKey } from 'uiohook-napi';
+
+export type KeyInfo = {
+  name: string;
+  isPrintable: boolean;
+  string?: string;
+  shiftString?: string;
+};
+
+export const keyInfoMap: Record<number, KeyInfo> = {
+  [UiohookKey.Backspace]: {
+    name: 'Backspace',
+    isPrintable: false,
+  },
+  [UiohookKey.Tab]: {
+    name: 'Tab',
+    isPrintable: false,
+  },
+  [UiohookKey.Enter]: {
+    name: 'Enter',
+    isPrintable: false,
+  },
+  [UiohookKey.CapsLock]: {
+    name: 'CapsLock',
+    isPrintable: false,
+  },
+  [UiohookKey.Escape]: {
+    name: 'Escape',
+    isPrintable: false,
+  },
+  [UiohookKey.Space]: {
+    name: 'Space',
+    isPrintable: true,
+    string: ' ',
+    shiftString: ' ',
+  },
+  [UiohookKey.PageUp]: {
+    name: 'PageUp',
+    isPrintable: false,
+  },
+  [UiohookKey.PageDown]: {
+    name: 'PageDown',
+    isPrintable: false,
+  },
+  [UiohookKey.End]: {
+    name: 'End',
+    isPrintable: false,
+  },
+  [UiohookKey.Home]: {
+    name: 'Home',
+    isPrintable: false,
+  },
+  [UiohookKey.ArrowLeft]: {
+    name: 'Left',
+    isPrintable: false,
+  },
+  [UiohookKey.ArrowUp]: {
+    name: 'Up',
+    isPrintable: false,
+  },
+  [UiohookKey.ArrowRight]: {
+    name: 'Right',
+    isPrintable: false,
+  },
+  [UiohookKey.ArrowDown]: {
+    name: 'Down',
+    isPrintable: false,
+  },
+  [UiohookKey.Insert]: {
+    name: 'Insert',
+    isPrintable: false,
+  },
+  [UiohookKey.Delete]: {
+    name: 'Delete',
+    isPrintable: false,
+  },
+
+  [UiohookKey.Numpad0]: {
+    name: 'Numpad0',
+    isPrintable: true,
+    string: '0',
+    shiftString: '0',
+  },
+  [UiohookKey.Numpad1]: {
+    name: 'Numpad1',
+    isPrintable: true,
+    string: '1',
+    shiftString: '1',
+  },
+  [UiohookKey.Numpad2]: {
+    name: 'Numpad2',
+    isPrintable: true,
+    string: '2',
+    shiftString: '2',
+  },
+  [UiohookKey.Numpad3]: {
+    name: 'Numpad3',
+    isPrintable: true,
+    string: '3',
+    shiftString: '3',
+  },
+  [UiohookKey.Numpad4]: {
+    name: 'Numpad4',
+    isPrintable: true,
+    string: '4',
+    shiftString: '4',
+  },
+  [UiohookKey.Numpad5]: {
+    name: 'Numpad5',
+    isPrintable: true,
+    string: '5',
+    shiftString: '5',
+  },
+  [UiohookKey.Numpad6]: {
+    name: 'Numpad6',
+    isPrintable: true,
+    string: '6',
+    shiftString: '6',
+  },
+  [UiohookKey.Numpad7]: {
+    name: 'Numpad7',
+    isPrintable: true,
+    string: '7',
+    shiftString: '7',
+  },
+  [UiohookKey.Numpad8]: {
+    name: 'Numpad8',
+    isPrintable: true,
+    string: '8',
+    shiftString: '8',
+  },
+  [UiohookKey.Numpad9]: {
+    name: 'Numpad9',
+    isPrintable: true,
+    string: '9',
+    shiftString: '9',
+  },
+
+  [UiohookKey.NumpadMultiply]: {
+    name: 'Multiply',
+    isPrintable: true,
+    string: '*',
+    shiftString: '*',
+  },
+  [UiohookKey.NumpadAdd]: {
+    name: 'Add',
+    isPrintable: true,
+    string: '+',
+    shiftString: '+',
+  },
+  [UiohookKey.NumpadSubtract]: {
+    name: 'Subtract',
+    isPrintable: true,
+    string: '-',
+    shiftString: '-',
+  },
+  [UiohookKey.NumpadDivide]: {
+    name: 'Divide',
+    isPrintable: true,
+    string: '/',
+    shiftString: '/',
+  },
+  [UiohookKey.NumpadDecimal]: {
+    name: 'Decimal',
+    isPrintable: true,
+    string: '.',
+    shiftString: '.',
+  },
+  [UiohookKey.NumpadEnter]: {
+    name: 'Enter',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadEnd]: {
+    name: 'End',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadArrowDown]: {
+    name: 'Down',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadArrowLeft]: {
+    name: 'Left',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadArrowRight]: {
+    name: 'Right',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadArrowUp]: {
+    name: 'Up',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadPageDown]: {
+    name: 'PageDown',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadPageUp]: {
+    name: 'PageUp',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadInsert]: {
+    name: 'Insert',
+    isPrintable: false,
+  },
+  [UiohookKey.NumpadDelete]: {
+    name: 'Delete',
+    isPrintable: false,
+  },
+  [UiohookKey.F1]: {
+    name: 'F1',
+    isPrintable: false,
+  },
+  [UiohookKey.F2]: {
+    name: 'F2',
+    isPrintable: false,
+  },
+  [UiohookKey.F3]: {
+    name: 'F3',
+    isPrintable: false,
+  },
+  [UiohookKey.F4]: {
+    name: 'F4',
+    isPrintable: false,
+  },
+  [UiohookKey.F5]: {
+    name: 'F5',
+    isPrintable: false,
+  },
+  [UiohookKey.F6]: {
+    name: 'F6',
+    isPrintable: false,
+  },
+  [UiohookKey.F7]: {
+    name: 'F7',
+    isPrintable: false,
+  },
+  [UiohookKey.F8]: {
+    name: 'F8',
+    isPrintable: false,
+  },
+  [UiohookKey.F9]: {
+    name: 'F9',
+    isPrintable: false,
+  },
+  [UiohookKey.F10]: {
+    name: 'F10',
+    isPrintable: false,
+  },
+  [UiohookKey.F11]: {
+    name: 'F11',
+    isPrintable: false,
+  },
+  [UiohookKey.F12]: {
+    name: 'F12',
+    isPrintable: false,
+  },
+  [UiohookKey.F13]: {
+    name: 'F13',
+    isPrintable: false,
+  },
+  [UiohookKey.F14]: {
+    name: 'F14',
+    isPrintable: false,
+  },
+  [UiohookKey.F15]: {
+    name: 'F15',
+    isPrintable: false,
+  },
+  [UiohookKey.F16]: {
+    name: 'F16',
+    isPrintable: false,
+  },
+  [UiohookKey.F17]: {
+    name: 'F17',
+    isPrintable: false,
+  },
+  [UiohookKey.F18]: {
+    name: 'F18',
+    isPrintable: false,
+  },
+  [UiohookKey.F19]: {
+    name: 'F19',
+    isPrintable: false,
+  },
+  [UiohookKey.F20]: {
+    name: 'F20',
+    isPrintable: false,
+  },
+  [UiohookKey.F21]: {
+    name: 'F21',
+    isPrintable: false,
+  },
+  [UiohookKey.F22]: {
+    name: 'F22',
+    isPrintable: false,
+  },
+  [UiohookKey.F23]: {
+    name: 'F23',
+    isPrintable: false,
+  },
+  [UiohookKey.F24]: {
+    name: 'F24',
+    isPrintable: false,
+  },
+  [UiohookKey.Semicolon]: {
+    name: 'Semicolon',
+    isPrintable: true,
+    string: ';',
+    shiftString: ':',
+  },
+  [UiohookKey.Equal]: {
+    name: 'Equal',
+    isPrintable: true,
+    string: '=',
+    shiftString: '+',
+  },
+  [UiohookKey.Comma]: {
+    name: 'Comma',
+    isPrintable: true,
+    string: ',',
+    shiftString: '"',
+  },
+  [UiohookKey.Minus]: {
+    name: 'Minus',
+    isPrintable: true,
+    string: '-',
+    shiftString: '_',
+  },
+  [UiohookKey.Period]: {
+    name: 'Period',
+    isPrintable: true,
+    string: '.',
+    shiftString: '>',
+  },
+  [UiohookKey.Slash]: {
+    name: 'Slash',
+    isPrintable: true,
+    string: '/',
+    shiftString: '?',
+  },
+  [UiohookKey.Backquote]: {
+    name: 'Grave',
+    isPrintable: true,
+    string: '`',
+    shiftString: '~',
+  },
+  [UiohookKey.BracketLeft]: {
+    name: 'LeftBracket',
+    isPrintable: true,
+    string: '[',
+    shiftString: '{',
+  },
+  [UiohookKey.BracketRight]: {
+    name: 'RightBracket',
+    isPrintable: true,
+    string: ']',
+    shiftString: '}',
+  },
+  [UiohookKey.Backslash]: {
+    name: 'Backslash',
+    isPrintable: true,
+    string: '\\',
+    shiftString: '|',
+  },
+  [UiohookKey.Quote]: {
+    name: 'Quote',
+    isPrintable: true,
+    string: "'",
+    shiftString: '"',
+  },
+  [UiohookKey.Ctrl]: {
+    name: 'LeftControl',
+    isPrintable: false,
+  },
+  [UiohookKey.CtrlRight]: {
+    name: 'RightControl',
+    isPrintable: false,
+  },
+  [UiohookKey.Shift]: {
+    name: 'LeftShift',
+    isPrintable: false,
+  },
+  [UiohookKey.ShiftRight]: {
+    name: 'RightShift',
+    isPrintable: false,
+  },
+  [UiohookKey.Alt]: {
+    name: 'LeftAlt',
+    isPrintable: false,
+  },
+  [UiohookKey.AltRight]: {
+    name: 'RightAlt',
+    isPrintable: false,
+  },
+  [UiohookKey.Meta]: {
+    name: 'LeftMeta',
+    isPrintable: false,
+  },
+  [UiohookKey.MetaRight]: {
+    name: 'RightMeta',
+    isPrintable: false,
+  },
+  [UiohookKey.NumLock]: {
+    name: 'NumLock',
+    isPrintable: false,
+  },
+  [UiohookKey.ScrollLock]: {
+    name: 'ScrollLock',
+    isPrintable: false,
+  },
+  [UiohookKey.PrintScreen]: {
+    name: 'Print',
+    isPrintable: false,
+  },
+
+  [UiohookKey.A]: {
+    name: 'A',
+    isPrintable: true,
+    string: 'a',
+    shiftString: 'A',
+  },
+  [UiohookKey.B]: {
+    name: 'B',
+    isPrintable: true,
+    string: 'b',
+    shiftString: 'B',
+  },
+  [UiohookKey.C]: {
+    name: 'C',
+    isPrintable: true,
+    string: 'c',
+    shiftString: 'C',
+  },
+  [UiohookKey.D]: {
+    name: 'D',
+    isPrintable: true,
+    string: 'd',
+    shiftString: 'D',
+  },
+  [UiohookKey.E]: {
+    name: 'E',
+    isPrintable: true,
+    string: 'e',
+    shiftString: 'E',
+  },
+  [UiohookKey.F]: {
+    name: 'F',
+    isPrintable: true,
+    string: 'f',
+    shiftString: 'F',
+  },
+  [UiohookKey.G]: {
+    name: 'G',
+    isPrintable: true,
+    string: 'g',
+    shiftString: 'G',
+  },
+  [UiohookKey.H]: {
+    name: 'H',
+    isPrintable: true,
+    string: 'h',
+    shiftString: 'H',
+  },
+  [UiohookKey.I]: {
+    name: 'I',
+    isPrintable: true,
+    string: 'i',
+    shiftString: 'I',
+  },
+  [UiohookKey.J]: {
+    name: 'J',
+    isPrintable: true,
+    string: 'j',
+    shiftString: 'J',
+  },
+  [UiohookKey.K]: {
+    name: 'K',
+    isPrintable: true,
+    string: 'k',
+    shiftString: 'K',
+  },
+  [UiohookKey.L]: {
+    name: 'L',
+    isPrintable: true,
+    string: 'l',
+    shiftString: 'L',
+  },
+  [UiohookKey.M]: {
+    name: 'M',
+    isPrintable: true,
+    string: 'm',
+    shiftString: 'M',
+  },
+  [UiohookKey.N]: {
+    name: 'N',
+    isPrintable: true,
+    string: 'n',
+    shiftString: 'N',
+  },
+  [UiohookKey.O]: {
+    name: 'O',
+    isPrintable: true,
+    string: 'o',
+    shiftString: 'O',
+  },
+  [UiohookKey.P]: {
+    name: 'P',
+    isPrintable: true,
+    string: 'p',
+    shiftString: 'P',
+  },
+  [UiohookKey.Q]: {
+    name: 'Q',
+    isPrintable: true,
+    string: 'q',
+    shiftString: 'Q',
+  },
+  [UiohookKey.R]: {
+    name: 'R',
+    isPrintable: true,
+    string: 'r',
+    shiftString: 'R',
+  },
+  [UiohookKey.S]: {
+    name: 'S',
+    isPrintable: true,
+    string: 's',
+    shiftString: 'S',
+  },
+  [UiohookKey.T]: {
+    name: 'T',
+    isPrintable: true,
+    string: 't',
+    shiftString: 'T',
+  },
+  [UiohookKey.U]: {
+    name: 'U',
+    isPrintable: true,
+    string: 'u',
+    shiftString: 'U',
+  },
+  [UiohookKey.V]: {
+    name: 'V',
+    isPrintable: true,
+    string: 'v',
+    shiftString: 'V',
+  },
+  [UiohookKey.W]: {
+    name: 'W',
+    isPrintable: true,
+    string: 'w',
+    shiftString: 'W',
+  },
+  [UiohookKey.X]: {
+    name: 'X',
+    isPrintable: true,
+    string: 'x',
+    shiftString: 'X',
+  },
+  [UiohookKey.Y]: {
+    name: 'Y',
+    isPrintable: true,
+    string: 'y',
+    shiftString: 'Y',
+  },
+  [UiohookKey.Z]: {
+    name: 'Z',
+    isPrintable: true,
+    string: 'z',
+    shiftString: 'Z',
+  },
+
+  [UiohookKey[0]]: {
+    name: '0',
+    isPrintable: true,
+    string: '0',
+    shiftString: ')',
+  },
+  [UiohookKey[1]]: {
+    name: '1',
+    isPrintable: true,
+    string: '1',
+    shiftString: '!',
+  },
+  [UiohookKey[2]]: {
+    name: '2',
+    isPrintable: true,
+    string: '2',
+    shiftString: '@',
+  },
+  [UiohookKey[3]]: {
+    name: '3',
+    isPrintable: true,
+    string: '3',
+    shiftString: '#',
+  },
+  [UiohookKey[4]]: {
+    name: '4',
+    isPrintable: true,
+    string: '4',
+    shiftString: '$',
+  },
+  [UiohookKey[5]]: {
+    name: '5',
+    isPrintable: true,
+    string: '5',
+    shiftString: '%',
+  },
+  [UiohookKey[6]]: {
+    name: '6',
+    isPrintable: true,
+    string: '6',
+    shiftString: '^',
+  },
+  [UiohookKey[7]]: {
+    name: '7',
+    isPrintable: true,
+    string: '7',
+    shiftString: '&',
+  },
+  [UiohookKey[8]]: {
+    name: '8',
+    isPrintable: true,
+    string: '8',
+    shiftString: '*',
+  },
+  [UiohookKey[9]]: {
+    name: '9',
+    isPrintable: true,
+    string: '9',
+    shiftString: '(',
+  },
+
+  [133]: {
+    name: 'LeftSuper',
+    isPrintable: false,
+  },
+  [134]: {
+    name: 'RightSuper',
+    isPrintable: false,
+  },
+  [0]: {
+    name: 'Alt',
+    isPrintable: false,
+  },
+};

--- a/packages/bytebotd/src/input-tracking/input-tracking.module.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { InputTrackingService } from './input-tracking.service';
 import { InputTrackingController } from './input-tracking.controller';
 import { InputTrackingGateway } from './input-tracking.gateway';
+import { ComputerUseModule } from '../computer-use/computer-use.module';
 
 @Module({
+  imports: [ComputerUseModule],
   controllers: [InputTrackingController],
   providers: [InputTrackingService, InputTrackingGateway],
   exports: [InputTrackingService, InputTrackingGateway],

--- a/packages/bytebotd/src/input-tracking/input-tracking.module.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { InputTrackingService } from './input-tracking.service';
+import { InputTrackingController } from './input-tracking.controller';
+import { InputTrackingGateway } from './input-tracking.gateway';
 
 @Module({
-  providers: [InputTrackingService],
-  exports: [InputTrackingService],
+  controllers: [InputTrackingController],
+  providers: [InputTrackingService, InputTrackingGateway],
+  exports: [InputTrackingService, InputTrackingGateway],
 })
 export class InputTrackingModule {}

--- a/packages/bytebotd/src/input-tracking/input-tracking.service.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.service.ts
@@ -281,11 +281,14 @@ export class InputTrackingService implements OnModuleDestroy {
   private async logAction(action: ComputerAction) {
     this.logger.log(`Detected action: ${JSON.stringify(action)}`);
 
-    if (this.screenshot && action.action === 'click_mouse') {
-      this.gateway.emitScreenshot(this.screenshot);
+    if (
+      this.screenshot &&
+      (action.action === 'click_mouse' || action.action === 'drag_mouse')
+    ) {
+      this.gateway.emitScreenshotAndAction(this.screenshot, action);
+      return;
     }
-    // wait for 100ms
-    await new Promise((resolve) => setTimeout(resolve, 300));
+
     this.gateway.emitAction(action);
   }
 }

--- a/packages/bytebotd/src/input-tracking/input-tracking.service.ts
+++ b/packages/bytebotd/src/input-tracking/input-tracking.service.ts
@@ -281,11 +281,11 @@ export class InputTrackingService implements OnModuleDestroy {
   private async logAction(action: ComputerAction) {
     this.logger.log(`Detected action: ${JSON.stringify(action)}`);
 
-    if (this.screenshot) {
+    if (this.screenshot && action.action === 'click_mouse') {
       this.gateway.emitScreenshot(this.screenshot);
     }
     // wait for 100ms
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 300));
     this.gateway.emitAction(action);
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./types/messageContent.types";
 export * from "./utils/messageContent.utils";
+export * from "./utils/computerAction.utils";
+export * from "./types/computerAction.types";

--- a/packages/shared/src/types/computerAction.types.ts
+++ b/packages/shared/src/types/computerAction.types.ts
@@ -1,0 +1,92 @@
+export type Coordinates = { x: number; y: number };
+export type Button = "left" | "right" | "middle";
+export type Press = "up" | "down";
+
+// Define individual computer action types
+export type MoveMouseAction = {
+  action: "move_mouse";
+  coordinates: Coordinates;
+};
+
+export type TraceMouseAction = {
+  action: "trace_mouse";
+  path: Coordinates[];
+  holdKeys?: string[];
+};
+
+export type ClickMouseAction = {
+  action: "click_mouse";
+  coordinates?: Coordinates;
+  button: Button;
+  holdKeys?: string[];
+  numClicks?: number;
+};
+
+export type PressMouseAction = {
+  action: "press_mouse";
+  coordinates?: Coordinates;
+  button: Button;
+  press: Press;
+};
+
+export type DragMouseAction = {
+  action: "drag_mouse";
+  path: Coordinates[];
+  button: Button;
+  holdKeys?: string[];
+};
+
+export type ScrollAction = {
+  action: "scroll";
+  coordinates?: Coordinates;
+  direction: "up" | "down" | "left" | "right";
+  numScrolls: number;
+  holdKeys?: string[];
+};
+
+export type TypeKeysAction = {
+  action: "type_keys";
+  keys: string[];
+  delay?: number;
+};
+
+export type PressKeysAction = {
+  action: "press_keys";
+  keys: string[];
+  press: Press;
+};
+
+export type TypeTextAction = {
+  action: "type_text";
+  text: string;
+  delay?: number;
+  isSensitive?: boolean;
+};
+
+export type WaitAction = {
+  action: "wait";
+  duration: number;
+};
+
+export type ScreenshotAction = {
+  action: "screenshot";
+};
+
+export type CursorPositionAction = {
+  action: "cursor_position";
+};
+
+// Define the union type using the individual action types
+export type ComputerAction =
+  | MoveMouseAction
+  | TraceMouseAction
+  | ClickMouseAction
+  | PressMouseAction
+  | DragMouseAction
+  | ScrollAction
+  | TypeKeysAction
+  | PressKeysAction
+  | TypeTextAction
+  | WaitAction
+  | ScreenshotAction
+  | CursorPositionAction;

--- a/packages/shared/src/types/messageContent.types.ts
+++ b/packages/shared/src/types/messageContent.types.ts
@@ -1,3 +1,5 @@
+import { Button, Coordinates, Press } from "./computerAction.types";
+
 // Content block types
 export enum MessageContentType {
   Text = "text",
@@ -32,10 +34,6 @@ export type ToolUseContentBlock = {
   id: string;
   input: Record<string, any>;
 } & MessageContentBlockBase;
-
-export type Coordinates = { x: number; y: number };
-export type Button = "left" | "right" | "middle";
-export type Press = "up" | "down";
 
 export type MoveMouseToolUseBlock = ToolUseContentBlock & {
   name: "computer_move_mouse";

--- a/packages/shared/src/utils/computerAction.utils.ts
+++ b/packages/shared/src/utils/computerAction.utils.ts
@@ -1,0 +1,241 @@
+import {
+  ClickMouseAction,
+  DragMouseAction,
+  MoveMouseAction,
+  PressKeysAction,
+  PressMouseAction,
+  ScrollAction,
+  TraceMouseAction,
+  TypeKeysAction,
+  TypeTextAction,
+} from "../types/computerAction.types";
+import {
+  ComputerToolUseContentBlock,
+  MessageContentType,
+} from "../types/messageContent.types";
+
+export function isMoveMouseAction(obj: unknown): obj is MoveMouseAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "move_mouse";
+}
+
+export function convertMoveMouseActionToToolUseBlock(
+  action: MoveMouseAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_move_mouse",
+    input: {
+      coordinates: action.coordinates,
+    },
+  };
+}
+
+export function isTraceMouseAction(obj: unknown): obj is TraceMouseAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "trace_mouse";
+}
+
+export function convertTraceMouseActionToToolUseBlock(
+  action: TraceMouseAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_trace_mouse",
+    input: {
+      path: action.path,
+      ...(action.holdKeys && { holdKeys: action.holdKeys }),
+    },
+  };
+}
+
+export function isClickMouseAction(obj: unknown): obj is ClickMouseAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "click_mouse";
+}
+
+export function convertClickMouseActionToToolUseBlock(
+  action: ClickMouseAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_click_mouse",
+    input: {
+      ...(action.coordinates && { coordinates: action.coordinates }),
+      button: action.button,
+      ...(action.holdKeys && { holdKeys: action.holdKeys }),
+      ...(typeof action.numClicks === "number" && {
+        numClicks: action.numClicks,
+      }),
+    },
+  };
+}
+
+export function isPressMouseAction(obj: unknown): obj is PressMouseAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "press_mouse";
+}
+
+export function convertPressMouseActionToToolUseBlock(
+  action: PressMouseAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_press_mouse",
+    input: {
+      ...(action.coordinates && { coordinates: action.coordinates }),
+      button: action.button,
+      press: action.press,
+    },
+  };
+}
+
+export function isDragMouseAction(obj: unknown): obj is DragMouseAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "drag_mouse";
+}
+
+export function convertDragMouseActionToToolUseBlock(
+  action: DragMouseAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_drag_mouse",
+    input: {
+      path: action.path,
+      button: action.button,
+      ...(action.holdKeys && { holdKeys: action.holdKeys }),
+    },
+  };
+}
+
+export function isScrollAction(obj: unknown): obj is ScrollAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "scroll";
+}
+
+export function convertScrollActionToToolUseBlock(
+  action: ScrollAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_scroll",
+    input: {
+      ...(action.coordinates && { coordinates: action.coordinates }),
+      direction: action.direction,
+      numScrolls: action.numScrolls,
+      ...(action.holdKeys && { holdKeys: action.holdKeys }),
+    },
+  };
+}
+
+export function isTypeKeysAction(obj: unknown): obj is TypeKeysAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "type_keys";
+}
+
+export function convertTypeKeysActionToToolUseBlock(
+  action: TypeKeysAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_type_keys",
+    input: {
+      keys: action.keys,
+      ...(typeof action.delay === "number" && { delay: action.delay }),
+    },
+  };
+}
+
+export function isPressKeysAction(obj: unknown): obj is PressKeysAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "press_keys";
+}
+
+export function convertPressKeysActionToToolUseBlock(
+  action: PressKeysAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_press_keys",
+    input: {
+      keys: action.keys,
+      press: action.press,
+    },
+  };
+}
+
+export function isTypeTextAction(obj: unknown): obj is TypeTextAction {
+  if (!obj || typeof obj !== "object") {
+    return false;
+  }
+
+  const action = obj as Record<string, any>;
+  return action.action === "type_text";
+}
+
+export function convertTypeTextActionToToolUseBlock(
+  action: TypeTextAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return {
+    type: MessageContentType.ToolUse,
+    id: toolUseId,
+    name: "computer_type_text",
+    input: {
+      text: action.text,
+      ...(typeof action.delay === "number" && { delay: action.delay }),
+      ...(typeof action.isSensitive === "boolean" && {
+        isSensitive: action.isSensitive,
+      }),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add input tracking controller and manual start/stop APIs
- buffer actions in daemon and allow retrieval
- start tracking when user takes over a task
- store tracked actions as task messages when control returns
- stream input actions directly instead of buffering

## Testing
- `npm test --silent --prefix packages/bytebotd` *(fails: jest not found)*
- `npm test --silent --prefix packages/bytebot-agent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841378158648329b2f46030441a5913