### PR TITLE
Add MCP support to bytebotd

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,22 @@ Use the computer control API for precise automation:
 The core container also exposes an [MCP](https://github.com/rekog-labs/MCP-Nest) endpoint.
 Connect your MCP client to `http://localhost:9990/sse` to invoke these tools over SSE.
 
+```json
+{
+  "mcpServers": {
+    "bytebot": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://127.0.0.1:9990/sse",
+        "--transport",
+        "http-first"
+      ]
+    }
+  }
+}
+```
+
 ```javascript
 // Take screenshot
 POST http://localhost:9990/computer-use

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ print(status.json())
 
 Use the computer control API for precise automation:
 
+The core container also exposes an [MCP](https://github.com/rekog-labs/MCP-Nest) endpoint.
+Connect your MCP client to `http://localhost:9990/sse` to invoke these tools over SSE.
+
 ```javascript
 // Take screenshot
 POST http://localhost:9990/computer-use

--- a/docs/core-concepts/architecture.mdx
+++ b/docs/core-concepts/architecture.mdx
@@ -31,6 +31,7 @@ The foundation of the system - a containerized Linux desktop that provides:
 - Consistent environment across different platforms
 - Can be customized with additional software
 - Accessible via REST API on port 9990
+- MCP SSE endpoint available at `/sse`
 
 ### 2. AI Agent Service
 The brain of the system - orchestrates tasks using an LLM:
@@ -82,7 +83,7 @@ Persistent storage for the agent system:
     Claude AI analyzes the task and generates a plan of computer actions
   </Step>
   <Step title="Action Execution">
-    Agent sends computer actions to bytebotd daemon via REST API
+    Agent sends computer actions to bytebotd via REST API or MCP
   </Step>
   <Step title="Desktop Automation">
     bytebotd executes actions (mouse, keyboard, screenshots) on the desktop
@@ -101,7 +102,7 @@ Persistent storage for the agent system:
 graph LR
     A[Tasks UI] -->|WebSocket| B[Agent Service]
     A -->|HTTP Proxy| C[Desktop VNC]
-    B -->|REST API| D[Desktop API]
+    B -->|REST/MCP| D[Desktop API]
     B -->|SQL| E[PostgreSQL]
     B -->|HTTPS| F[Claude AI]
     D -->|IPC| G[bytebotd]
@@ -128,7 +129,7 @@ graph LR
 
 ### API Security
 
-- **Desktop API**: No authentication by default (localhost only)
+ - **Desktop API**: No authentication by default (localhost only). Supports REST and MCP.
 - **Agent API**: Can be secured with API keys
 - **Database**: Password protected, not exposed externally
 - **VNC Access**: Optional password protection

--- a/docs/core-concepts/desktop-environment.mdx
+++ b/docs/core-concepts/desktop-environment.mdx
@@ -132,6 +132,27 @@ Navigate to `http://localhost:9990/vnc` for instant access:
 - Supports touch devices
 - Clipboard sharing
 
+### MCP Control
+
+The core container also exposes an [MCP](https://github.com/rekog-labs/MCP-Nest) endpoint.
+Connect your MCP client to `http://localhost:9990/sse` to invoke these tools over SSE.
+
+```json
+{
+  "mcpServers": {
+    "bytebot": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://127.0.0.1:9990/sse",
+        "--transport",
+        "http-first"
+      ]
+    }
+  }
+}
+```
+
 ### Direct API Control
 Most efficient for automation:
 ```bash

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -114,6 +114,7 @@ Watch it work in real-time through the embedded VNC viewer in the tasks interfac
 | **Tasks UI**     | [http://localhost:9992](http://localhost:9992)                           | Main interface for interacting with the agent |
 | **Agent API**    | [http://localhost:9991/tasks](http://localhost:9991/tasks)               | REST API for programmatic task creation       |
 | **Computer API** | [http://localhost:9990/computer-use](http://localhost:9990/computer-use) | Low-level desktop control API                 |
+| **MCP SSE**      | [http://localhost:9990/sse](http://localhost:9990/sse)                 | Connect MCP clients for tool access           |
 
 ## Alternative Deployment Options
 

--- a/packages/bytebotd/package-lock.json
+++ b/packages/bytebotd/package-lock.json
@@ -23,6 +23,7 @@
         "http-proxy-middleware": "^3.0.5",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "sharp": "^0.34.2",
         "socket.io": "^4.8.1",
         "uiohook-napi": "^1.5.4"
       },
@@ -775,6 +776,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
@@ -990,6 +1001,402 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz",
+      "integrity": "sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.2.tgz",
+      "integrity": "sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz",
+      "integrity": "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz",
+      "integrity": "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
+      "integrity": "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz",
+      "integrity": "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz",
+      "integrity": "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz",
+      "integrity": "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.2.tgz",
+      "integrity": "sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.2.tgz",
+      "integrity": "sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz",
+      "integrity": "sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.2.tgz",
+      "integrity": "sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.2.tgz",
+      "integrity": "sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.2.tgz",
+      "integrity": "sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.2.tgz",
+      "integrity": "sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.4.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.2.tgz",
+      "integrity": "sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.2.tgz",
+      "integrity": "sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.2.tgz",
+      "integrity": "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -5494,11 +5901,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5511,8 +5930,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5857,6 +6285,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -10721,10 +11158,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10814,6 +11250,47 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
+      "integrity": "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.4",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.2",
+        "@img/sharp-darwin-x64": "0.34.2",
+        "@img/sharp-libvips-darwin-arm64": "1.1.0",
+        "@img/sharp-libvips-darwin-x64": "1.1.0",
+        "@img/sharp-libvips-linux-arm": "1.1.0",
+        "@img/sharp-libvips-linux-arm64": "1.1.0",
+        "@img/sharp-libvips-linux-ppc64": "1.1.0",
+        "@img/sharp-libvips-linux-s390x": "1.1.0",
+        "@img/sharp-libvips-linux-x64": "1.1.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
+        "@img/sharp-linux-arm": "0.34.2",
+        "@img/sharp-linux-arm64": "0.34.2",
+        "@img/sharp-linux-s390x": "0.34.2",
+        "@img/sharp-linux-x64": "0.34.2",
+        "@img/sharp-linuxmusl-arm64": "0.34.2",
+        "@img/sharp-linuxmusl-x64": "0.34.2",
+        "@img/sharp-wasm32": "0.34.2",
+        "@img/sharp-win32-arm64": "0.34.2",
+        "@img/sharp-win32-ia32": "0.34.2",
+        "@img/sharp-win32-x64": "0.34.2"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -10920,6 +11397,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/packages/bytebotd/package-lock.json
+++ b/packages/bytebotd/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/serve-static": "^5.0.3",
         "@nestjs/websockets": "^11.1.2",
         "@nut-tree-fork/nut-js": "^4.2.6",
+        "@rekog/mcp-nest": "^1.6.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "http-proxy-middleware": "^3.0.5",
@@ -2423,6 +2424,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.2.tgz",
+      "integrity": "sha512-Vx7qOcmoKkR3qhaQ9qf3GxiVKCEu+zfJddHv6x3dY/9P6+uIwJnmuAur5aB+4FDXf41rRrDnOEGkviX5oYZ67w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.1.tgz",
@@ -3103,6 +3127,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@rekog/mcp-nest": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@rekog/mcp-nest/-/mcp-nest-1.6.2.tgz",
+      "integrity": "sha512-swcu99a/woQ5T1f4E/YJct1w/xzszH83bhzEuZwXh+cYRnQUJKhaJd5Aey/XyOtt/D9lQTKSdnoKdpija8kuWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-to-regexp": "^8.2.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.10.0",
+        "@nestjs/common": ">=9.0.0",
+        "@nestjs/core": ">=9.0.0",
+        "express": ">=4.0.0",
+        "reflect-metadata": ">=0.1.14",
+        "zod": ">=3.0.0",
+        "zod-to-json-schema": ">=3.23.0"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -4299,7 +4341,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -5688,7 +5729,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6421,6 +6461,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6525,6 +6588,22 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -6596,7 +6675,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -6647,7 +6725,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8773,7 +8850,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -9765,7 +9841,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9916,6 +9991,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -10123,7 +10208,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10735,7 +10819,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10748,7 +10831,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12138,7 +12220,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -12461,7 +12542,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12747,6 +12827,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/packages/bytebotd/package.json
+++ b/packages/bytebotd/package.json
@@ -34,14 +34,15 @@
     "@nestjs/serve-static": "^5.0.3",
     "@nestjs/websockets": "^11.1.2",
     "@nut-tree-fork/nut-js": "^4.2.6",
+    "@rekog/mcp-nest": "^1.6.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "http-proxy-middleware": "^3.0.5",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "sharp": "^0.34.2",
     "socket.io": "^4.8.1",
-    "uiohook-napi": "^1.5.4",
-    "@rekog/mcp-nest": "^1.6.2"
+    "uiohook-napi": "^1.5.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/packages/bytebotd/package.json
+++ b/packages/bytebotd/package.json
@@ -40,7 +40,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",
-    "uiohook-napi": "^1.5.4"
+    "uiohook-napi": "^1.5.4",
+    "@rekog/mcp-nest": "^1.6.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/packages/bytebotd/src/app.module.ts
+++ b/packages/bytebotd/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { BytebotMcpModule } from './mcp';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { AppService } from './app.service';
     }),
     ComputerUseModule,
     InputTrackingModule,
+    BytebotMcpModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/packages/bytebotd/src/mcp/bytebot-mcp.module.ts
+++ b/packages/bytebotd/src/mcp/bytebot-mcp.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { McpModule } from '@rekog/mcp-nest';
+import { ComputerUseModule } from '../computer-use/computer-use.module';
+import { ComputerUseTools } from './computer-use.tools';
+
+@Module({
+  imports: [
+    ComputerUseModule,
+    McpModule.forRoot({
+      name: 'bytebotd',
+      version: '0.0.1',
+      sseEndpoint: '/sse',
+    }),
+  ],
+  providers: [ComputerUseTools],
+})
+export class BytebotMcpModule {}

--- a/packages/bytebotd/src/mcp/compressor.ts
+++ b/packages/bytebotd/src/mcp/compressor.ts
@@ -1,0 +1,233 @@
+import * as sharp from 'sharp';
+
+interface CompressionOptions {
+  targetSizeKB?: number;
+  initialQuality?: number;
+  minQuality?: number;
+  format?: 'png' | 'jpeg' | 'webp';
+  maxIterations?: number;
+}
+
+interface CompressionResult {
+  base64: string;
+  sizeBytes: number;
+  sizeKB: number;
+  sizeMB: number;
+  quality: number;
+  format: string;
+  iterations: number;
+}
+
+class Base64ImageCompressor {
+  /**
+   * Compress a base64 PNG string to under specified size (default 1MB)
+   */
+  static async compressToSize(
+    base64String: string,
+    options: CompressionOptions = {},
+  ): Promise<CompressionResult> {
+    const {
+      targetSizeKB = 1024, // 1MB default
+      initialQuality = 95,
+      minQuality = 10,
+      format = 'png',
+      maxIterations = 10,
+    } = options;
+
+    // Extract base64 data (remove data URL prefix if present)
+    const base64Data = base64String.replace(/^data:image\/\w+;base64,/, '');
+    const inputBuffer = Buffer.from(base64Data, 'base64');
+
+    let quality = initialQuality;
+    let outputBuffer: Buffer;
+    let iterations = 0;
+
+    // Binary search for optimal quality
+    let low = minQuality;
+    let high = initialQuality;
+    let bestResult: { buffer: Buffer; quality: number } | null = null;
+
+    while (low <= high && iterations < maxIterations) {
+      quality = Math.floor((low + high) / 2);
+
+      outputBuffer = await this.compressBuffer(inputBuffer, quality, format);
+      const sizeKB = outputBuffer.length / 1024;
+
+      if (sizeKB <= targetSizeKB) {
+        // Size is acceptable, try higher quality
+        bestResult = { buffer: outputBuffer, quality };
+        low = quality + 1;
+      } else {
+        // Size too large, reduce quality
+        high = quality - 1;
+      }
+
+      iterations++;
+    }
+
+    // If no result found under target size, use lowest quality
+    if (!bestResult) {
+      outputBuffer = await this.compressBuffer(inputBuffer, minQuality, format);
+      quality = minQuality;
+    } else {
+      outputBuffer = bestResult.buffer;
+      quality = bestResult.quality;
+    }
+
+    // Convert back to base64
+    const outputBase64 = outputBuffer.toString('base64');
+    const sizeBytes = outputBuffer.length;
+
+    return {
+      base64: outputBase64,
+      sizeBytes,
+      sizeKB: sizeBytes / 1024,
+      sizeMB: sizeBytes / (1024 * 1024),
+      quality,
+      format,
+      iterations,
+    };
+  }
+
+  /**
+   * Compress buffer with specified quality
+   */
+  private static async compressBuffer(
+    inputBuffer: Buffer,
+    quality: number,
+    format: 'png' | 'jpeg' | 'webp',
+  ): Promise<Buffer> {
+    let sharpInstance = sharp(inputBuffer);
+
+    switch (format) {
+      case 'png':
+        return sharpInstance
+          .png({
+            quality,
+            compressionLevel: 9,
+            adaptiveFiltering: true,
+            palette: true,
+          })
+          .toBuffer();
+
+      case 'jpeg':
+        return sharpInstance
+          .jpeg({
+            quality,
+            progressive: true,
+            mozjpeg: true,
+            optimizeScans: true,
+          })
+          .toBuffer();
+
+      case 'webp':
+        return sharpInstance
+          .webp({
+            quality,
+            alphaQuality: quality,
+            lossless: false,
+            nearLossless: false,
+            smartSubsample: true,
+          })
+          .toBuffer();
+
+      default:
+        throw new Error(`Unsupported format: ${format}`);
+    }
+  }
+
+  /**
+   * Compress with dimension reduction if quality alone isn't enough
+   */
+  static async compressWithResize(
+    base64String: string,
+    options: CompressionOptions & {
+      maxWidth?: number;
+      maxHeight?: number;
+    } = {},
+  ): Promise<CompressionResult> {
+    const {
+      targetSizeKB = 1024,
+      maxWidth = 2048,
+      maxHeight = 2048,
+      ...compressionOptions
+    } = options;
+
+    // First try compression without resizing
+    let result = await this.compressToSize(base64String, compressionOptions);
+
+    // If still too large, apply progressive resizing
+    if (result.sizeKB > targetSizeKB) {
+      const base64Data = base64String.replace(/^data:image\/\w+;base64,/, '');
+      const inputBuffer = Buffer.from(base64Data, 'base64');
+
+      const metadata = await sharp(inputBuffer).metadata();
+      const originalWidth = metadata.width || maxWidth;
+      const originalHeight = metadata.height || maxHeight;
+
+      let scale = 0.9; // Start with 90% of original size
+
+      while (result.sizeKB > targetSizeKB && scale > 0.3) {
+        const newWidth = Math.floor(originalWidth * scale);
+        const newHeight = Math.floor(originalHeight * scale);
+
+        const resizedBuffer = await sharp(inputBuffer)
+          .resize(newWidth, newHeight, {
+            fit: 'inside',
+            withoutEnlargement: true,
+          })
+          .toBuffer();
+
+        const resizedBase64 = resizedBuffer.toString('base64');
+
+        result = await this.compressToSize(resizedBase64, compressionOptions);
+        scale -= 0.1;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Get size information for a base64 string
+   */
+  static getBase64SizeInfo(base64String: string): {
+    bytes: number;
+    kb: number;
+    mb: number;
+    formatted: string;
+  } {
+    const base64Data = base64String.replace(/^data:image\/\w+;base64,/, '');
+    const bytes = Buffer.from(base64Data, 'base64').length;
+    const kb = bytes / 1024;
+    const mb = bytes / (1024 * 1024);
+
+    let formatted: string;
+    if (mb >= 1) {
+      formatted = `${mb.toFixed(2)} MB`;
+    } else if (kb >= 1) {
+      formatted = `${kb.toFixed(2)} KB`;
+    } else {
+      formatted = `${bytes} bytes`;
+    }
+
+    return { bytes, kb, mb, formatted };
+  }
+}
+
+// Utility function for quick compression
+export async function compressPngBase64Under1MB(
+  base64String: string,
+): Promise<string> {
+  const result = await Base64ImageCompressor.compressToSize(base64String, {
+    targetSizeKB: 1024,
+    format: 'png',
+    initialQuality: 95,
+    minQuality: 10,
+  });
+
+  return result.base64;
+}
+
+// Export the class for more control
+export { Base64ImageCompressor, CompressionOptions, CompressionResult };

--- a/packages/bytebotd/src/mcp/computer-use.tools.ts
+++ b/packages/bytebotd/src/mcp/computer-use.tools.ts
@@ -1,0 +1,386 @@
+import { Injectable } from '@nestjs/common';
+import { Tool } from '@rekog/mcp-nest';
+import { z } from 'zod';
+import { ComputerUseService } from '../computer-use/computer-use.service';
+import { MessageContentType } from '@bytebot/shared';
+
+@Injectable()
+export class ComputerUseTools {
+  constructor(private readonly computerUse: ComputerUseService) {}
+
+  @Tool({
+    name: 'computer_move_mouse',
+    description: 'Move the mouse to specific coordinates.',
+    parameters: z.object({
+      coordinates: z.object({ x: z.number(), y: z.number() }),
+    }),
+  })
+  async moveMouse({ coordinates }: { coordinates: { x: number; y: number } }) {
+    try {
+      await this.computerUse.action({ action: 'move_mouse', coordinates });
+      return { content: [{ type: MessageContentType.Text, text: 'mouse moved' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error moving mouse: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_trace_mouse',
+    description: 'Trace a path with the mouse.',
+    parameters: z.object({
+      path: z.array(z.object({ x: z.number(), y: z.number() })),
+      holdKeys: z.array(z.string()).optional(),
+    }),
+  })
+  async traceMouse({
+    path,
+    holdKeys,
+  }: {
+    path: { x: number; y: number }[];
+    holdKeys?: string[];
+  }) {
+    try {
+      await this.computerUse.action({ action: 'trace_mouse', path, holdKeys });
+      return {
+        content: [{ type: MessageContentType.Text, text: 'mouse traced' }],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error tracing mouse: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_click_mouse',
+    description: 'Perform mouse clicks.',
+    parameters: z.object({
+      coordinates: z.object({ x: z.number(), y: z.number() }).optional(),
+      button: z.enum(['left', 'right', 'middle']),
+      holdKeys: z.array(z.string()).optional(),
+      numClicks: z.number(),
+    }),
+  })
+  async clickMouse({
+    coordinates,
+    button,
+    holdKeys,
+    numClicks,
+  }: {
+    coordinates?: { x: number; y: number };
+    button: 'left' | 'right' | 'middle';
+    holdKeys?: string[];
+    numClicks: number;
+  }) {
+    try {
+      await this.computerUse.action({
+        action: 'click_mouse',
+        coordinates,
+        button,
+        holdKeys,
+        numClicks,
+      });
+      return {
+        content: [{ type: MessageContentType.Text, text: 'mouse clicked' }],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error clicking mouse: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_press_mouse',
+    description: 'Press or release a mouse button.',
+    parameters: z.object({
+      coordinates: z.object({ x: z.number(), y: z.number() }).optional(),
+      button: z.enum(['left', 'right', 'middle']),
+      press: z.enum(['down', 'up']),
+    }),
+  })
+  async pressMouse({
+    coordinates,
+    button,
+    press,
+  }: {
+    coordinates?: { x: number; y: number };
+    button: 'left' | 'right' | 'middle';
+    press: 'down' | 'up';
+  }) {
+    try {
+      await this.computerUse.action({
+        action: 'press_mouse',
+        coordinates,
+        button,
+        press,
+      });
+      return {
+        content: [{ type: MessageContentType.Text, text: 'mouse pressed' }],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error pressing mouse: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_drag_mouse',
+    description: 'Drag the mouse along a path.',
+    parameters: z.object({
+      path: z.array(z.object({ x: z.number(), y: z.number() })),
+      button: z.enum(['left', 'right', 'middle']),
+      holdKeys: z.array(z.string()).optional(),
+    }),
+  })
+  async dragMouse({
+    path,
+    button,
+    holdKeys,
+  }: {
+    path: { x: number; y: number }[];
+    button: 'left' | 'right' | 'middle';
+    holdKeys?: string[];
+  }) {
+    try {
+      await this.computerUse.action({
+        action: 'drag_mouse',
+        path,
+        button,
+        holdKeys,
+      });
+      return {
+        content: [{ type: MessageContentType.Text, text: 'mouse dragged' }],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error dragging mouse: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_scroll',
+    description: 'Scroll the mouse wheel.',
+    parameters: z.object({
+      coordinates: z.object({ x: z.number(), y: z.number() }).optional(),
+      direction: z.enum(['up', 'down', 'left', 'right']),
+      numScrolls: z.number(),
+      holdKeys: z.array(z.string()).optional(),
+    }),
+  })
+  async scroll({
+    coordinates,
+    direction,
+    numScrolls,
+    holdKeys,
+  }: {
+    coordinates?: { x: number; y: number };
+    direction: 'up' | 'down' | 'left' | 'right';
+    numScrolls: number;
+    holdKeys?: string[];
+  }) {
+    try {
+      await this.computerUse.action({
+        action: 'scroll',
+        coordinates,
+        direction,
+        numScrolls,
+        holdKeys,
+      });
+      return { content: [{ type: MessageContentType.Text, text: 'scrolled' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error scrolling: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_type_keys',
+    description: 'Press a sequence of keys.',
+    parameters: z.object({
+      keys: z.array(z.string()),
+      delay: z.number().optional(),
+    }),
+  })
+  async typeKeys({ keys, delay }: { keys: string[]; delay?: number }) {
+    try {
+      await this.computerUse.action({ action: 'type_keys', keys, delay });
+      return { content: [{ type: MessageContentType.Text, text: 'keys typed' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error typing keys: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_press_keys',
+    description: 'Hold or release keys.',
+    parameters: z.object({
+      keys: z.array(z.string()),
+      press: z.enum(['down', 'up']),
+    }),
+  })
+  async pressKeys({ keys, press }: { keys: string[]; press: 'down' | 'up' }) {
+    try {
+      await this.computerUse.action({ action: 'press_keys', keys, press });
+      return { content: [{ type: MessageContentType.Text, text: 'keys pressed' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error pressing keys: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_type_text',
+    description: 'Type a text string.',
+    parameters: z.object({
+      text: z.string(),
+      delay: z.number().optional(),
+    }),
+  })
+  async typeText({ text, delay }: { text: string; delay?: number }) {
+    try {
+      await this.computerUse.action({ action: 'type_text', text, delay });
+      return { content: [{ type: MessageContentType.Text, text: 'text typed' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error typing text: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_wait',
+    description: 'Wait for a period of time.',
+    parameters: z.object({ duration: z.number() }),
+  })
+  async wait({ duration }: { duration: number }) {
+    try {
+      await this.computerUse.action({ action: 'wait', duration });
+      return { content: [{ type: MessageContentType.Text, text: 'waiting done' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error waiting: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_screenshot',
+    description: 'Capture a screenshot of the desktop.',
+  })
+  async screenshot() {
+    try {
+      const shot = (await this.computerUse.action({
+        action: 'screenshot',
+      })) as { image: string };
+      return {
+        content: [
+          {
+            type: MessageContentType.Image,
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: shot.image,
+            },
+          },
+        ],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error taking screenshot: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_cursor_position',
+    description: 'Get the current cursor position.',
+  })
+  async cursorPosition() {
+    try {
+      const pos = (await this.computerUse.action({
+        action: 'cursor_position',
+      })) as { x: number; y: number };
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: JSON.stringify(pos),
+          },
+        ],
+      };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: MessageContentType.Text,
+            text: `Error getting cursor position: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+}

--- a/packages/bytebotd/src/mcp/index.ts
+++ b/packages/bytebotd/src/mcp/index.ts
@@ -1,0 +1,1 @@
+export * from './bytebot-mcp.module';


### PR DESCRIPTION
## Summary
- add `@rekog/mcp-nest` dependency
- expose computer-use actions as MCP tools with a new `BytebotMcpModule`
- return tool results as MCP content blocks
- document new MCP SSE endpoint in README and docs
- handle errors in MCP tools

## Testing
- `npm test -- --passWithNoTests` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685f005c286c8329a34e324b90efe5f5