### PR TITLE
Add OpenAI service

### DIFF
--- a/packages/bytebot-agent/package-lock.json
+++ b/packages/bytebot-agent/package-lock.json
@@ -23,6 +23,7 @@
         "@thallesp/nestjs-better-auth": "^1.0.0",
         "better-auth": "^1.2.9",
         "class-validator": "^0.14.2",
+        "openai": "^5.8.2",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.1",
@@ -6378,6 +6379,27 @@
         }
       }
     },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -6439,6 +6461,27 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9635,6 +9678,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.8.2.tgz",
+      "integrity": "sha512-8C+nzoHYgyYOXhHGN6r0fcb4SznuEn1R7YZMvlqDbnCuE0FM2mm3T1HiYW6WIcMS/F1Of2up/cSPjLPaWt0X9Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10829,6 +10893,27 @@
       },
       "peerDependenciesMeta": {
         "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -12540,9 +12625,12 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -36,6 +36,7 @@
     "@thallesp/nestjs-better-auth": "^1.0.0",
     "better-auth": "^1.2.9",
     "class-validator": "^0.14.2",
+    "openai": "^5.8.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",

--- a/packages/bytebot-agent/src/openai/openai.constants.ts
+++ b/packages/bytebot-agent/src/openai/openai.constants.ts
@@ -1,0 +1,110 @@
+export const DEFAULT_DISPLAY_SIZE = {
+  width: 1280,
+  height: 960,
+};
+
+export const DEFAULT_COMPUTER_TOOL_USE_NAME = 'computer_20250124';
+
+export const AGENT_SYSTEM_PROMPT = `
+You are **Bytebot**, a highly-reliable AI engineer operating a virtual computer whose display measures ${DEFAULT_DISPLAY_SIZE.width} × ${DEFAULT_DISPLAY_SIZE.height} pixels.
+
+The current date is ${new Date().toLocaleDateString()}. The current time is ${new Date().toLocaleTimeString()}. The current timezone is ${Intl.DateTimeFormat().resolvedOptions().timeZone}.
+
+
+────────────────────────
+AVAILABLE APPLICATIONS
+────────────────────────
+
+On the computer, the following applications are available:
+
+Firefox Browser -- The default web browser, use it to navigate to websites.
+Thunderbird -- The default email client, use it to send and receive emails (if you have an account).
+1Password -- The password manager, use it to store and retrieve your passwords (if you have an account).
+Terminal -- The default terminal, use it to run commands.
+File Manager -- The default file manager, use it to navigate and manage files.
+Trash -- The default trash, use it to delete files.
+
+ALL APPLICATIONS ARE GUI BASED, USE THE COMPUTER TOOLS TO INTERACT WITH THEM. ONLY ACCESS THE APPLICATIONS VIA THEIR DESKTOP ICONS.
+
+*Never* use keyboard shortcuts to switch between applications.
+
+*Never* open the 'Applications' menu from the dock.
+
+
+────────────────────────
+CORE WORKING PRINCIPLES
+────────────────────────
+1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document.
+2. **Human-Like Interaction**
+   • Move in smooth, purposeful paths; click near the visual centre of targets.
+
+   • Double-click desktop icons to open them.
+   • Type realistic, context-appropriate text with \`computer_type_text\` or shortcuts with \`computer_type_keys\`.
+3. **Valid Keys Only** -
+   Use **exactly** the identifiers listed in **VALID KEYS** below when supplying \`keys\` to \`computer_type_keys\` or \`computer_press_keys\`. All identifiers come from nut-tree's \`Key\` enum; they are case-sensitive and contain *no spaces*.
+4. **Verify Every Step** - After each action:
+   a. \`computer_wait\` for 500ms, or longer if absolutely necessary.
+   b. Take another screenshot.
+   c. Confirm the expected state before continuing. If it failed, retry sensibly or abort with \`"status":"failed"\`.
+5. **Efficiency & Clarity** - Combine related key presses; prefer scrolling or dragging over many small moves; minimise unnecessary waits.
+6. **Stay Within Scope** - Do nothing the user didn't request; don't suggest unrelated tasks.
+7. **Security** - If you see a password, secret key, or other sensitive information (or the user shares it with you), do not repeat it in conversation. When typing sensitive information, use \`computer_type_text\` with \`isSensitive\` set to \`true\`.
+
+────────────────────────
+TASK LIFECYCLE TEMPLATE
+────────────────────────
+1. **Prepare** - Initial screenshot → plan.
+2. **Execute Loop** - For each sub-goal: Screenshot → Think → Act → Wait → Verify.
+3. **Create other tasks** - If you need to create additional tasks, invoke
+
+   \`\`\`json
+   { "name": "create_task", "input": { "description": "Subtask description", "type": "IMMEDIATE", "priority": "MEDIUM" } }
+   \`\`\`
+   The tasks will be executed in the order they are created, after the current task is completed.
+4. **Schedule future tasks** - If you need to schedule a task to run in the future, invoke
+   \`\`\`json
+{ "name": "create_task", "input": { "description": "Subtask description", "type": "SCHEDULED", "scheduledFor": <ISO Date>, "priority": "MEDIUM" } }
+   \`\`\`
+5. ** Ask for Help** - If you need clarification, invoke
+   \`\`\`json
+   { "name": "set_task_status", "input": { "status": "needs_help" } }
+   \`\`\`
+6. **Cleanup** - When the user's goal is met:
+   • Close every window, file, or app you opened so the desktop is tidy.
+   • Return to an idle desktop/background.
+7. **Terminate** - As your final tool call and message, invoke
+   \`\`\`json
+   { "name": "set_task_status", "input": { "status": "completed" } }
+   \`\`\`
+   (or \`"failed"\` if unrecoverable). No further actions or messages follow this call.
+
+────────────────────────
+VALID KEYS
+────────────────────────
+A, Add, AudioForward, AudioMute, AudioNext, AudioPause, AudioPlay, AudioPrev, AudioRandom, AudioRepeat, AudioRewind, AudioStop, AudioVolDown, AudioVolUp,
+B, Backslash, Backspace,
+C, CapsLock, Clear, Comma,
+D, Decimal, Delete, Divide, Down,
+E, End, Enter, Equal, Escape, F,
+F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15, F16, F17, F18, F19, F20, F21, F22, F23, F24,
+Fn,
+G, Grave,
+H, Home,
+I, Insert,
+J, K, L, Left, LeftAlt, LeftBracket, LeftCmd, LeftControl, LeftShift, LeftSuper, LeftWin,
+M, Menu, Minus, Multiply,
+N, Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9, NumLock,
+NumPad0, NumPad1, NumPad2, NumPad3, NumPad4, NumPad5, NumPad6, NumPad7, NumPad8, NumPad9,
+O, P, PageDown, PageUp, Pause, Period, Print,
+Q, Quote,
+R, Return, Right, RightAlt, RightBracket, RightCmd, RightControl, RightShift, RightSuper, RightWin,
+S, ScrollLock, Semicolon, Slash, Space, Subtract,
+T, Tab,
+U, Up,
+V, W, X, Y, Z
+
+Remember: **accuracy over speed, clarity over cleverness**.
+Think before each move, keep the desktop clean when you're done, and **always** finish with \`set_task_status\`.
+`;
+
+export const DEFAULT_MODEL = 'gpt-4o';

--- a/packages/bytebot-agent/src/openai/openai.module.ts
+++ b/packages/bytebot-agent/src/openai/openai.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { OpenAIService } from './openai.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [OpenAIService],
+  exports: [OpenAIService],
+})
+export class OpenAIModule {}

--- a/packages/bytebot-agent/src/openai/openai.service.ts
+++ b/packages/bytebot-agent/src/openai/openai.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import OpenAI from 'openai';
+import {
+  MessageContentBlock,
+  MessageContentType,
+  TextContentBlock,
+  ToolUseContentBlock,
+} from '@bytebot/shared';
+import { AGENT_SYSTEM_PROMPT, DEFAULT_MODEL } from './openai.constants';
+import { Message, Role } from '@prisma/client';
+import { openaiTools } from './openai.tools';
+
+@Injectable()
+export class OpenAIService {
+  private readonly openai: OpenAI;
+  private readonly logger = new Logger(OpenAIService.name);
+
+  constructor(private readonly configService: ConfigService) {
+    const apiKey = this.configService.get<string>('OPENAI_API_KEY');
+
+    if (!apiKey) {
+      this.logger.warn(
+        'OPENAI_API_KEY is not set. OpenAIService will not work properly.',
+      );
+    }
+
+    this.openai = new OpenAI({
+      apiKey: apiKey || 'dummy-key-for-initialization',
+    });
+  }
+
+  async sendMessage(
+    messages: Message[],
+    signal?: AbortSignal,
+  ): Promise<MessageContentBlock[]> {
+    try {
+      const model = DEFAULT_MODEL;
+      const maxTokens = 8192;
+
+      const openaiMessages = this.formatMessagesForOpenAI(messages);
+
+      const response = await this.openai.chat.completions.create(
+        {
+          model,
+          max_tokens: maxTokens,
+          messages: [
+            { role: 'system', content: AGENT_SYSTEM_PROMPT },
+            ...openaiMessages,
+          ],
+          tools: openaiTools,
+        },
+        { signal },
+      );
+
+      return this.formatOpenAIResponse(response.choices[0].message);
+    } catch (error: any) {
+      if (error?.name === 'AbortError') {
+        this.logger.log('OpenAI API call aborted');
+        throw error;
+      }
+      this.logger.error(
+        `Error sending message to OpenAI: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+
+  private formatMessagesForOpenAI(
+    messages: Message[],
+  ): OpenAI.ChatCompletionMessageParam[] {
+    const openaiMessages: OpenAI.ChatCompletionMessageParam[] = [];
+
+    for (const message of messages) {
+      const blocks = message.content as MessageContentBlock[];
+
+      if (
+        message.role === Role.USER &&
+        blocks.some((b) => b.type === MessageContentType.ToolUse)
+      ) {
+        continue;
+      }
+
+      if (
+        message.role === Role.USER &&
+        blocks.every((b) => b.type === MessageContentType.ToolResult)
+      ) {
+        for (const block of blocks) {
+          if (block.type !== MessageContentType.ToolResult) continue;
+          const content = this.blocksToParts(block.content);
+          openaiMessages.push({
+            role: 'tool',
+            tool_call_id: block.tool_use_id,
+            content,
+          });
+        }
+        continue;
+      }
+
+      const role = message.role === Role.USER ? 'user' : 'assistant';
+      const contentParts = this.blocksToParts(
+        blocks.filter((b) => b.type !== MessageContentType.ToolUse),
+      );
+      const toolCalls = blocks
+        .filter((b) => b.type === MessageContentType.ToolUse)
+        .map((b) => ({
+          id: (b as ToolUseContentBlock).id,
+          type: 'function' as const,
+          function: {
+            name: (b as ToolUseContentBlock).name,
+            arguments: JSON.stringify((b as ToolUseContentBlock).input ?? {}),
+          },
+        }));
+
+      openaiMessages.push({
+        role,
+        content: contentParts.length > 0 ? contentParts : null,
+        ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+      });
+    }
+
+    return openaiMessages;
+  }
+
+  private blocksToParts(
+    blocks: MessageContentBlock[],
+  ): OpenAI.ChatCompletionContentPart[] {
+    const parts: OpenAI.ChatCompletionContentPart[] = [];
+
+    for (const block of blocks) {
+      switch (block.type) {
+        case MessageContentType.Text:
+          parts.push({ type: 'text', text: block.text });
+          break;
+        case MessageContentType.Image:
+          parts.push({
+            type: 'image_url',
+            image_url: {
+              url: `data:${block.source.media_type};base64,${block.source.data}`,
+            },
+          });
+          break;
+        case MessageContentType.ToolResult:
+          const text = block.content
+            .map((b) =>
+              b.type === MessageContentType.Text ? b.text : JSON.stringify(b),
+            )
+            .join('\n');
+          parts.push({ type: 'text', text });
+          break;
+      }
+    }
+
+    return parts;
+  }
+
+  private formatOpenAIResponse(
+    message: OpenAI.ChatCompletionMessage,
+  ): MessageContentBlock[] {
+    const blocks: MessageContentBlock[] = [];
+
+    const content = message.content;
+    if (typeof content === 'string') {
+      if (content.trim().length > 0) {
+        blocks.push({ type: MessageContentType.Text, text: content });
+      }
+    } else if (Array.isArray(content)) {
+      for (const part of content) {
+        if (part.type === 'text') {
+          blocks.push({ type: MessageContentType.Text, text: part.text });
+        } else if (part.type === 'image_url') {
+          blocks.push({
+            type: MessageContentType.Image,
+            source: {
+              data: part.image_url.url.replace(/^data:image\/png;base64,/, ''),
+              media_type: 'image/png',
+              type: 'base64',
+            },
+          });
+        }
+      }
+    }
+
+    if ('tool_calls' in message && message.tool_calls) {
+      for (const call of message.tool_calls) {
+        blocks.push({
+          type: MessageContentType.ToolUse,
+          id: call.id,
+          name: call.function.name,
+          input: JSON.parse(call.function.arguments || '{}'),
+        } as ToolUseContentBlock);
+      }
+    }
+
+    return blocks;
+  }
+}

--- a/packages/bytebot-agent/src/openai/openai.tools.ts
+++ b/packages/bytebot-agent/src/openai/openai.tools.ts
@@ -1,0 +1,72 @@
+import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import {
+  _moveMouseTool,
+  _traceMouseTool,
+  _clickMouseTool,
+  _pressMouseTool,
+  _dragMouseTool,
+  _scrollTool,
+  _typeKeysTool,
+  _pressKeysTool,
+  _typeTextTool,
+  _waitTool,
+  _screenshotTool,
+  _cursorPositionTool,
+  _setTaskStatusTool,
+  _createTaskTool,
+} from '../agent/agent.tools';
+
+function agentToolToOpenAITool(agentTool: any): ChatCompletionTool {
+  return {
+    type: 'function',
+    function: {
+      name: agentTool.name,
+      description: agentTool.description,
+      parameters: agentTool.input_schema,
+    },
+  } as ChatCompletionTool;
+}
+
+export const moveMouseTool: ChatCompletionTool =
+  agentToolToOpenAITool(_moveMouseTool);
+export const traceMouseTool: ChatCompletionTool =
+  agentToolToOpenAITool(_traceMouseTool);
+export const clickMouseTool: ChatCompletionTool =
+  agentToolToOpenAITool(_clickMouseTool);
+export const pressMouseTool: ChatCompletionTool =
+  agentToolToOpenAITool(_pressMouseTool);
+export const dragMouseTool: ChatCompletionTool =
+  agentToolToOpenAITool(_dragMouseTool);
+export const scrollTool: ChatCompletionTool =
+  agentToolToOpenAITool(_scrollTool);
+export const typeKeysTool: ChatCompletionTool =
+  agentToolToOpenAITool(_typeKeysTool);
+export const pressKeysTool: ChatCompletionTool =
+  agentToolToOpenAITool(_pressKeysTool);
+export const typeTextTool: ChatCompletionTool =
+  agentToolToOpenAITool(_typeTextTool);
+export const waitTool: ChatCompletionTool = agentToolToOpenAITool(_waitTool);
+export const screenshotTool: ChatCompletionTool =
+  agentToolToOpenAITool(_screenshotTool);
+export const cursorPositionTool: ChatCompletionTool =
+  agentToolToOpenAITool(_cursorPositionTool);
+export const setTaskStatusTool: ChatCompletionTool =
+  agentToolToOpenAITool(_setTaskStatusTool);
+export const createTaskTool: ChatCompletionTool =
+  agentToolToOpenAITool(_createTaskTool);
+
+export const openaiTools: ChatCompletionTool[] = [
+  moveMouseTool,
+  traceMouseTool,
+  clickMouseTool,
+  pressMouseTool,
+  dragMouseTool,
+  scrollTool,
+  typeKeysTool,
+  pressKeysTool,
+  typeTextTool,
+  screenshotTool,
+  cursorPositionTool,
+  setTaskStatusTool,
+  createTaskTool,
+];


### PR DESCRIPTION
## Summary
- add OpenAI dependency
- implement `OpenAIService` with same interface as existing `AnthropicService`
- expose `OpenAIModule`
- convert agent tools into OpenAI tool definitions
- document default OpenAI constants

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68656cfb76a8832992055666d02c6fde