### PR TITLE
Feature/log token usage in lumen

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
+      - LUMEN_API_KEY=${LUMEN_API_KEY}
+      - LUMEN_API_URL=${LUMEN_API_URL}
     depends_on:
       - postgres
     networks:

--- a/packages/bytebot-agent/package-lock.json
+++ b/packages/bytebot-agent/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@bytebot/shared": "../shared",
+        "@getlumen/server": "^0.1.2",
         "@google/genai": "^1.8.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -1003,6 +1004,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@getlumen/server": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@getlumen/server/-/server-0.1.2.tgz",
+      "integrity": "sha512-Ig88fF9LZuiCl1/Nt3YKAAvPNaYyQlQJ+FQZ0BLC29dka8IuLdmZNDrtfoOr//uGSQ1t+DlD+gdw1D3niwpdhQ==",
+      "license": "ISC"
     },
     "node_modules/@google/genai": {
       "version": "1.8.0",

--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@bytebot/shared": "../shared",
+    "@getlumen/server": "^0.1.2",
     "@google/genai": "^1.8.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",

--- a/packages/bytebot-agent/src/anthropic/anthropic.module.ts
+++ b/packages/bytebot-agent/src/anthropic/anthropic.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AnthropicService } from './anthropic.service';
+import { LumenModule } from '../lumen/lumen.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, LumenModule],
   providers: [AnthropicService],
   exports: [AnthropicService],
 })

--- a/packages/bytebot-agent/src/anthropic/anthropic.service.ts
+++ b/packages/bytebot-agent/src/anthropic/anthropic.service.ts
@@ -74,6 +74,7 @@ export class AnthropicService {
         },
         { signal },
       );
+      this.logger.debug('Anthropic Response:', JSON.stringify(response.usage, null, 2));
 
       // Convert Anthropic's response to our message content blocks format
       return this.formatAnthropicResponse(response.content);

--- a/packages/bytebot-agent/src/google/google.module.ts
+++ b/packages/bytebot-agent/src/google/google.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { GoogleService } from './google.service';
+import { LumenModule } from '../lumen/lumen.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, LumenModule],
   providers: [GoogleService],
   exports: [GoogleService],
 })

--- a/packages/bytebot-agent/src/google/google.service.ts
+++ b/packages/bytebot-agent/src/google/google.service.ts
@@ -74,6 +74,11 @@ export class GoogleService {
           },
         });
 
+      // Log usage information
+      if (response.usageMetadata) {
+        this.logger.log(`Google Gemini usage: ${JSON.stringify(response.usageMetadata, null, 2)}`);
+      }
+
       const candidate = response.candidates?.[0];
 
       if (!candidate) {

--- a/packages/bytebot-agent/src/lumen/lumen.module.ts
+++ b/packages/bytebot-agent/src/lumen/lumen.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { LumenService } from './lumen.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [LumenService],
+  exports: [LumenService],
+})
+export class LumenModule {}

--- a/packages/bytebot-agent/src/lumen/lumen.service.ts
+++ b/packages/bytebot-agent/src/lumen/lumen.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { sendEvent } from '@getlumen/server';
+
+export interface LumenEventData {
+  name: string;
+  userId?: string;
+  value: string;
+}
+
+@Injectable()
+export class LumenService {
+  private readonly logger = new Logger(LumenService.name);
+  private readonly lumenApiKey: string | undefined;
+  private readonly lumenApiUrl: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.lumenApiKey = this.configService.get<string>('LUMEN_API_KEY');
+    this.lumenApiUrl =
+      this.configService.get<string>('LUMEN_API_URL') ||
+      'https://api.getlumen.dev';
+
+    if (!this.lumenApiKey) {
+      this.logger.warn(
+        'LUMEN_API_KEY is not set. Lumen event logging will be disabled.',
+      );
+    }
+  }
+
+  async sendEvent(eventData: LumenEventData): Promise<void> {
+    if (!this.lumenApiKey) {
+      this.logger.debug('Lumen API key not configured, skipping event send');
+      return;
+    }
+
+    try {
+      await sendEvent({
+        name: eventData.name,
+        userId: eventData.userId || `bytebot-agent-${process.env.HOSTNAME}`,
+        value: eventData.value,
+        apiUrl: this.lumenApiUrl,
+        apiKey: this.lumenApiKey,
+      });
+
+      this.logger.debug(`Lumen event sent successfully: ${eventData.name}`);
+    } catch (error) {
+      this.logger.error('Error sending Lumen event:', error);
+    }
+  }
+
+  async sendApiUsageEvent(
+    provider: string,
+    usageData: any,
+    additionalData?: Record<string, any>,
+  ): Promise<void> {
+    // Combine usage data with additional data for the event value
+    const eventValue = additionalData
+      ? JSON.stringify({ ...usageData, ...additionalData })
+      : JSON.stringify(usageData);
+
+    await this.sendEvent({
+      name: `${provider}-api-call`,
+      value: eventValue,
+    });
+  }
+
+  isConfigured(): boolean {
+    return !!this.lumenApiKey;
+  }
+}

--- a/packages/bytebot-agent/src/openai/openai.module.ts
+++ b/packages/bytebot-agent/src/openai/openai.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { OpenAIService } from './openai.service';
+import { LumenModule } from '../lumen/lumen.module';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, LumenModule],
   providers: [OpenAIService],
   exports: [OpenAIService],
 })

--- a/packages/bytebot-agent/src/openai/openai.service.ts
+++ b/packages/bytebot-agent/src/openai/openai.service.ts
@@ -57,10 +57,12 @@ export class OpenAIService {
         { signal },
       );
 
+      this.logger.debug('OpenAI Response:', JSON.stringify(response.usage, null, 2));
+
       return this.formatOpenAIResponse(response.output);
     } catch (error: any) {
-      console.log('error', error);
-      console.log('error name', error.name);
+      this.logger.error('OpenAI API error:', error);
+      this.logger.error('Error name:', error.name);
 
       if (error instanceof APIUserAbortError) {
         this.logger.log('OpenAI API call aborted');

--- a/packages/bytebot-agent/src/openai/openai.service.ts
+++ b/packages/bytebot-agent/src/openai/openai.service.ts
@@ -15,13 +15,17 @@ import {
   AGENT_SYSTEM_PROMPT,
   BytebotAgentInterrupt,
 } from '../agent/agent.constants';
+import { LumenService } from '../lumen/lumen.service';
 
 @Injectable()
 export class OpenAIService {
   private readonly openai: OpenAI;
   private readonly logger = new Logger(OpenAIService.name);
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly lumenService: LumenService,
+  ) {
     const apiKey = this.configService.get<string>('OPENAI_API_KEY');
 
     if (!apiKey) {
@@ -57,7 +61,10 @@ export class OpenAIService {
         { signal },
       );
 
-      this.logger.debug('OpenAI Response:', JSON.stringify(response.usage, null, 2));
+      await this.lumenService.sendApiUsageEvent('openai', response.usage, {
+        model,
+        messageCount: messages.length,
+      });
 
       return this.formatOpenAIResponse(response.output);
     } catch (error: any) {


### PR DESCRIPTION
This PR adds the option to log usage in lumen payments to track token spent (https://getlumen.dev)

The only required env var is LUMEN_API_KEY. If not provided nothing will be logged.

Only the amount of tokens used and model are logged, prompts and outputs are not logged.