### PR TITLE
Add application tool

### DIFF
--- a/packages/bytebot-agent/src/agent/agent.computer-use.ts
+++ b/packages/bytebot-agent/src/agent/agent.computer-use.ts
@@ -18,6 +18,7 @@ import {
   isTypeTextToolUseBlock,
   isWaitToolUseBlock,
   isApplicationToolUseBlock,
+  isPasteTextToolUseBlock,
 } from '@bytebot/shared';
 import { Logger } from '@nestjs/common';
 
@@ -131,6 +132,9 @@ export async function handleComputerToolUse(
     }
     if (isTypeTextToolUseBlock(block)) {
       await typeText(block.input);
+    }
+    if (isPasteTextToolUseBlock(block)) {
+      await pasteText(block.input);
     }
     if (isWaitToolUseBlock(block)) {
       await wait(block.input);
@@ -391,6 +395,25 @@ async function typeText(input: {
     });
   } catch (error) {
     console.error('Error in type_text action:', error);
+    throw error;
+  }
+}
+
+async function pasteText(input: { text: string }): Promise<void> {
+  const { text } = input;
+  console.log(`Pasting text: ${text}`);
+
+  try {
+    await fetch(`${BYTEBOT_DESKTOP_BASE_URL}/computer-use`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'paste_text',
+        text,
+      }),
+    });
+  } catch (error) {
+    console.error('Error in paste_text action:', error);
     throw error;
   }
 }

--- a/packages/bytebot-agent/src/agent/agent.computer-use.ts
+++ b/packages/bytebot-agent/src/agent/agent.computer-use.ts
@@ -17,6 +17,7 @@ import {
   isPressKeysToolUseBlock,
   isTypeTextToolUseBlock,
   isWaitToolUseBlock,
+  isApplicationToolUseBlock,
 } from '@bytebot/shared';
 import { Logger } from '@nestjs/common';
 
@@ -133,6 +134,9 @@ export async function handleComputerToolUse(
     }
     if (isWaitToolUseBlock(block)) {
       await wait(block.input);
+    }
+    if (isApplicationToolUseBlock(block)) {
+      await application(block.input);
     }
     logger.debug(`Tool execution successful for tool_use_id: ${block.id}`);
     return {
@@ -457,6 +461,25 @@ async function screenshot(): Promise<string> {
     return data.image; // Base64 encoded image
   } catch (error) {
     console.error('Error in screenshot action:', error);
+    throw error;
+  }
+}
+
+async function application(input: { application: string }): Promise<void> {
+  const { application } = input;
+  console.log(`Opening application: ${application}`);
+
+  try {
+    await fetch(`${BYTEBOT_DESKTOP_BASE_URL}/computer-use`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'application',
+        application,
+      }),
+    });
+  } catch (error) {
+    console.error('Error in application action:', error);
     throw error;
   }
 }

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -41,19 +41,20 @@ ALL APPLICATIONS ARE GUI BASED, USE THE COMPUTER TOOLS TO INTERACT WITH THEM. ON
 CORE WORKING PRINCIPLES
 ────────────────────────
 1. **Observe First** - *Always* invoke \`computer_screenshot\` before your first action **and** whenever the UI may have changed. Screenshot before every action when filling out forms. Never act blindly. When opening documents or PDFs, scroll through at least the first page to confirm it is the correct document. 
-2. **Human-Like Interaction**
+2. **Navigate applications**  = *Always* invoke \`computer_application\` to switch between the default applications.
+3. **Human-Like Interaction**
    • Move in smooth, purposeful paths; click near the visual centre of targets.  
    • Double-click desktop icons to open them.  
    • Type realistic, context-appropriate text with \`computer_type_text\` or shortcuts with \`computer_type_keys\`.
-3. **Valid Keys Only** - 
+4. **Valid Keys Only** - 
    Use **exactly** the identifiers listed in **VALID KEYS** below when supplying \`keys\` to \`computer_type_keys\` or \`computer_press_keys\`. All identifiers come from nut-tree's \`Key\` enum; they are case-sensitive and contain *no spaces*.
-4. **Verify Every Step** - After each action:  
+5. **Verify Every Step** - After each action:  
    a. Take another screenshot.  
    b. Confirm the expected state before continuing. If it failed, retry sensibly or abort with \`"status":"failed"\`.
-5. **Efficiency & Clarity** - Combine related key presses; prefer scrolling or dragging over many small moves; minimise unnecessary waits.
-6. **Stay Within Scope** - Do nothing the user didn't request; don't suggest unrelated tasks.
-7. **Security** - If you see a password, secret key, or other sensitive information (or the user shares it with you), do not repeat it in conversation. When typing sensitive information, use \`computer_type_text\` with \`isSensitive\` set to \`true\`.
-8. **Consistency & Persistence** - Even if the task is repetitive, do not end the task until the user's goal is completely met. For bulk operations, maintain focus and continue until all items are processed.
+6. **Efficiency & Clarity** - Combine related key presses; prefer scrolling or dragging over many small moves; minimise unnecessary waits.
+7. **Stay Within Scope** - Do nothing the user didn't request; don't suggest unrelated tasks.
+8. **Security** - If you see a password, secret key, or other sensitive information (or the user shares it with you), do not repeat it in conversation. When typing sensitive information, use \`computer_type_text\` with \`isSensitive\` set to \`true\`.
+9. **Consistency & Persistence** - Even if the task is repetitive, do not end the task until the user's goal is completely met. For bulk operations, maintain focus and continue until all items are processed.
 
 ────────────────────────
 REPETITIVE TASK HANDLING

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -45,7 +45,7 @@ CORE WORKING PRINCIPLES
 3. **Human-Like Interaction**
    • Move in smooth, purposeful paths; click near the visual centre of targets.  
    • Double-click desktop icons to open them.  
-   • Type realistic, context-appropriate text with \`computer_type_text\` or shortcuts with \`computer_type_keys\`.
+   • Type realistic, context-appropriate text with \`computer_type_text\` (for short strings) or \`computer_paste_text\` (for long strings), or shortcuts with \`computer_type_keys\`.
 4. **Valid Keys Only** - 
    Use **exactly** the identifiers listed in **VALID KEYS** below when supplying \`keys\` to \`computer_type_keys\` or \`computer_press_keys\`. All identifiers come from nut-tree's \`Key\` enum; they are case-sensitive and contain *no spaces*.
 5. **Verify Every Step** - After each action:  

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -28,14 +28,14 @@ On the computer, the following applications are available:
 Firefox Browser -- The default web browser, use it to navigate to websites.
 Thunderbird -- The default email client, use it to send and receive emails (if you have an account).
 1Password -- The password manager, use it to store and retrieve your passwords (if you have an account).
-Visual Studio Code -- The default code editor, use it to edit files.
+Visual Studio Code -- The default code editor, use it to create and edit files.
 Terminal -- The default terminal, use it to run commands.
 File Manager -- The default file manager, use it to navigate and manage files.
-Trash -- The default trash, use it to delete files.
+Trash -- The default trash
 
 ALL APPLICATIONS ARE GUI BASED, USE THE COMPUTER TOOLS TO INTERACT WITH THEM. ONLY ACCESS THE APPLICATIONS VIA THEIR DESKTOP ICONS.
 
-*Never* use keyboard shortcuts to switch between applications. 
+*Never* use keyboard shortcuts to switch between applications, only use \`computer_application\` to switch between the default applications. 
 
 ────────────────────────
 CORE WORKING PRINCIPLES
@@ -86,10 +86,9 @@ When performing repetitive tasks (e.g., "visit each profile", "process all items
    • You reach a clear endpoint (e.g., "No more profiles to load"), OR
    • The user explicitly tells you to stop
 
-6. **State Management** - If the task might span multiple sessions:
+6. **State Management** - If the task might span multiple tabs/pages:
    • Save progress to a file periodically
    • Include timestamps and item identifiers
-   • Be prepared to resume from a specific point
 
 ────────────────────────
 TASK LIFECYCLE TEMPLATE
@@ -131,7 +130,7 @@ TASK LIFECYCLE TEMPLATE
    \`\`\`json
    { "name": "set_task_status", "input": { "status": "completed" } }
    \`\`\`  
-   Or, if the task is unrecoverable, invoke          
+   Or, if the task is failed or unrecoverable, invoke          
    \`\`\`json
    { "name": "set_task_status", "input": { "status": "failed" } }
    \`\`\`  
@@ -169,7 +168,7 @@ U, Up,
 V, W, X, Y, Z
 
 Remember: **accuracy over speed, clarity and consistency over cleverness**.  
-Think before each move, keep the desktop clean when you're done, and **always** finish with \`set_task_status\`.
+Think before each move, keep the desktop clean when you're done, and **always** finish with \`set_task_status\`. Don't ask follow-up questions after completing the task.
 
 **For repetitive tasks**: Persistence is key. Continue until ALL items are processed, not just the first few.
 `;

--- a/packages/bytebot-agent/src/agent/agent.constants.ts
+++ b/packages/bytebot-agent/src/agent/agent.constants.ts
@@ -28,6 +28,7 @@ On the computer, the following applications are available:
 Firefox Browser -- The default web browser, use it to navigate to websites.
 Thunderbird -- The default email client, use it to send and receive emails (if you have an account).
 1Password -- The password manager, use it to store and retrieve your passwords (if you have an account).
+Visual Studio Code -- The default code editor, use it to edit files.
 Terminal -- The default terminal, use it to run commands.
 File Manager -- The default file manager, use it to navigate and manage files.
 Trash -- The default trash, use it to delete files.
@@ -101,24 +102,31 @@ TASK LIFECYCLE TEMPLATE
      - Check for stop conditions
      - Brief status update
    • Continue until ALL done
-4. **Create other tasks** - If you need to create additional separate tasks, invoke          
+
+4. **Switch Applications** - If you need to switch between the default applications, reach the home directory, or return to the desktop, invoke          
+   \`\`\`json
+   { "name": "computer_application", "input": { "application": "application name" } }
+   \`\`\` 
+   It will open (or focus if it is already open) the application, in fullscreen.
+   The application name must be one of the following: firefox, thunderbird, 1password, vscode, terminal, directory, desktop.
+5. **Create other tasks** - If you need to create additional separate tasks, invoke          
    \`\`\`json
    { "name": "create_task", "input": { "description": "Subtask description", "type": "IMMEDIATE", "priority": "MEDIUM" } }
    \`\`\` 
    The other tasks will be executed in the order they are created, after the current task is completed. Only create separate tasks if they are not related to the current task.
-5. **Schedule future tasks** - If you need to schedule a task to run in the future, invoke          
+6. **Schedule future tasks** - If you need to schedule a task to run in the future, invoke          
    \`\`\`json
 { "name": "create_task", "input": { "description": "Subtask description", "type": "SCHEDULED", "scheduledFor": <ISO Date>, "priority": "MEDIUM" } }
    \`\`\` 
    Only schedule tasks if they must be run in the future. Do not schedule tasks that can be run immediately.
-6. **Ask for Help** - If you need clarification, invoke          
+7. **Ask for Help** - If you need clarification, invoke          
    \`\`\`json
    { "name": "set_task_status", "input": { "status": "needs_help" } }
    \`\`\`  
-7. **Cleanup** - When the user's goal is met:  
+8. **Cleanup** - When the user's goal is met:  
    • Close every window, file, or app you opened so the desktop is tidy.  
    • Return to an idle desktop/background.  
-8. **Terminate** - ONLY ONCE THE USER'S GOAL IS MET, As your final tool call and message, invoke          
+9. **Terminate** - ONLY ONCE THE USER'S GOAL IS MET, As your final tool call and message, invoke          
    \`\`\`json
    { "name": "set_task_status", "input": { "status": "completed" } }
    \`\`\`  

--- a/packages/bytebot-agent/src/agent/agent.processor.ts
+++ b/packages/bytebot-agent/src/agent/agent.processor.ts
@@ -50,7 +50,6 @@ export class AgentProcessor {
     private readonly anthropicService: AnthropicService,
     private readonly openaiService: OpenAIService,
     private readonly googleService: GoogleService,
-    private readonly configService: ConfigService,
     private readonly inputCaptureService: InputCaptureService,
   ) {
     this.services = {
@@ -385,6 +384,8 @@ export class AgentProcessor {
 
     // Signal any in-flight async operations to abort
     this.abortController?.abort();
+
+    await this.inputCaptureService.stop();
 
     this.isProcessing = false;
     this.currentTaskId = null;

--- a/packages/bytebot-agent/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent/src/agent/agent.tools.ts
@@ -202,7 +202,7 @@ export const _pressKeysTool = {
 export const _typeTextTool = {
   name: 'computer_type_text',
   description:
-    'Types a string of text character by character. Useful for strings less than 25 characters, or passwords/sensitive form fields.',
+    'Types a string of text character by character. Use this tool for strings less than 25 characters, or passwords/sensitive form fields.',
   input_schema: {
     type: 'object' as const,
     properties: {
@@ -228,7 +228,7 @@ export const _typeTextTool = {
 export const _pasteTextTool = {
   name: 'computer_paste_text',
   description:
-    'Copies text to the clipboard and pastes it. Useful for large text or special characters not on the standard keyboard.',
+    'Copies text to the clipboard and pastes it. Use this tool for typing long text strings or special characters not on the standard keyboard.',
   input_schema: {
     type: 'object' as const,
     properties: {

--- a/packages/bytebot-agent/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent/src/agent/agent.tools.ts
@@ -263,14 +263,21 @@ export const _cursorPositionTool = {
 
 export const _applicationTool = {
   name: 'computer_application',
-  description:
-    'Opens or focuses an application and ensures it is fullscreen',
+  description: 'Opens or focuses an application and ensures it is fullscreen',
   input_schema: {
     type: 'object' as const,
     properties: {
       application: {
         type: 'string' as const,
-        enum: ['firefox', '1password', 'thunderbird', 'vscode', 'terminal'],
+        enum: [
+          'firefox',
+          '1password',
+          'thunderbird',
+          'vscode',
+          'terminal',
+          'desktop',
+          'directory',
+        ],
         description: 'The application to open or focus',
       },
     },

--- a/packages/bytebot-agent/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent/src/agent/agent.tools.ts
@@ -201,7 +201,8 @@ export const _pressKeysTool = {
 
 export const _typeTextTool = {
   name: 'computer_type_text',
-  description: 'Types a string of text character by character',
+  description:
+    'Types a string of text character by character. Useful for strings less than 25 characters, or passwords/sensitive form fields.',
   input_schema: {
     type: 'object' as const,
     properties: {
@@ -213,6 +214,27 @@ export const _typeTextTool = {
         type: 'number' as const,
         description: 'Optional delay in milliseconds between characters',
         nullable: true,
+      },
+      isSensitive: {
+        type: 'boolean' as const,
+        description: 'Flag to indicate sensitive information',
+        nullable: true,
+      },
+    },
+    required: ['text'],
+  },
+};
+
+export const _pasteTextTool = {
+  name: 'computer_paste_text',
+  description:
+    'Copies text to the clipboard and pastes it. Useful for large text or special characters not on the standard keyboard.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      text: {
+        type: 'string' as const,
+        description: 'The text string to type',
       },
       isSensitive: {
         type: 'boolean' as const,
@@ -347,6 +369,7 @@ export const agentTools = [
   _typeKeysTool,
   _pressKeysTool,
   _typeTextTool,
+  _pasteTextTool,
   _waitTool,
   _screenshotTool,
   _applicationTool,

--- a/packages/bytebot-agent/src/agent/agent.tools.ts
+++ b/packages/bytebot-agent/src/agent/agent.tools.ts
@@ -261,6 +261,23 @@ export const _cursorPositionTool = {
   },
 };
 
+export const _applicationTool = {
+  name: 'computer_application',
+  description:
+    'Opens or focuses an application and ensures it is fullscreen',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      application: {
+        type: 'string' as const,
+        enum: ['firefox', '1password', 'thunderbird', 'vscode', 'terminal'],
+        description: 'The application to open or focus',
+      },
+    },
+    required: ['application'],
+  },
+};
+
 /**
  * Tool definitions for task management
  */
@@ -325,6 +342,7 @@ export const agentTools = [
   _typeTextTool,
   _waitTool,
   _screenshotTool,
+  _applicationTool,
   _cursorPositionTool,
   _setTaskStatusTool,
   _createTaskTool,

--- a/packages/bytebot-agent/src/anthropic/anthropic.tools.ts
+++ b/packages/bytebot-agent/src/anthropic/anthropic.tools.ts
@@ -11,21 +11,24 @@ function agentToolToAnthropicTool(agentTool: any): Anthropic.Tool {
 /**
  * Creates a mapped object of tools by name
  */
-const toolMap = agentTools.reduce((acc, tool) => {
-  const anthropicTool = agentToolToAnthropicTool(tool);
-  const camelCaseName = tool.name
-    .split('_')
-    .map((part, index) => {
-      if (index === 0) return part;
-      if (part === 'computer') return '';
-      return part.charAt(0).toUpperCase() + part.slice(1);
-    })
-    .join('')
-    .replace(/^computer/, '');
-  
-  acc[camelCaseName + 'Tool'] = anthropicTool;
-  return acc;
-}, {} as Record<string, Anthropic.Tool>);
+const toolMap = agentTools.reduce(
+  (acc, tool) => {
+    const anthropicTool = agentToolToAnthropicTool(tool);
+    const camelCaseName = tool.name
+      .split('_')
+      .map((part, index) => {
+        if (index === 0) return part;
+        if (part === 'computer') return '';
+        return part.charAt(0).toUpperCase() + part.slice(1);
+      })
+      .join('')
+      .replace(/^computer/, '');
+
+    acc[camelCaseName + 'Tool'] = anthropicTool;
+    return acc;
+  },
+  {} as Record<string, Anthropic.Tool>,
+);
 
 // Export individual tools with proper names
 export const moveMouseTool = toolMap.moveMouseTool;
@@ -37,11 +40,15 @@ export const scrollTool = toolMap.scrollTool;
 export const typeKeysTool = toolMap.typeKeysTool;
 export const pressKeysTool = toolMap.pressKeysTool;
 export const typeTextTool = toolMap.typeTextTool;
+export const pasteTextTool = toolMap.pasteTextTool;
 export const waitTool = toolMap.waitTool;
 export const screenshotTool = toolMap.screenshotTool;
 export const cursorPositionTool = toolMap.cursorPositionTool;
 export const setTaskStatusTool = toolMap.setTaskStatusTool;
 export const createTaskTool = toolMap.createTaskTool;
+export const applicationTool = toolMap.applicationTool;
 
 // Array of all tools
-export const anthropicTools: Anthropic.Tool[] = agentTools.map(agentToolToAnthropicTool);
+export const anthropicTools: Anthropic.Tool[] = agentTools.map(
+  agentToolToAnthropicTool,
+);

--- a/packages/bytebot-agent/src/google/google.tools.ts
+++ b/packages/bytebot-agent/src/google/google.tools.ts
@@ -108,11 +108,13 @@ export const scrollTool = toolMap.scrollTool;
 export const typeKeysTool = toolMap.typeKeysTool;
 export const pressKeysTool = toolMap.pressKeysTool;
 export const typeTextTool = toolMap.typeTextTool;
+export const pasteTextTool = toolMap.pasteTextTool;
 export const waitTool = toolMap.waitTool;
 export const screenshotTool = toolMap.screenshotTool;
 export const cursorPositionTool = toolMap.cursorPositionTool;
 export const setTaskStatusTool = toolMap.setTaskStatusTool;
 export const createTaskTool = toolMap.createTaskTool;
+export const applicationTool = toolMap.applicationTool;
 
 // Array of all tools
 export const googleTools: FunctionDeclaration[] = agentTools.map(

--- a/packages/bytebot-agent/src/openai/openai.tools.ts
+++ b/packages/bytebot-agent/src/openai/openai.tools.ts
@@ -42,11 +42,13 @@ export const scrollTool = toolMap.scrollTool;
 export const typeKeysTool = toolMap.typeKeysTool;
 export const pressKeysTool = toolMap.pressKeysTool;
 export const typeTextTool = toolMap.typeTextTool;
+export const pasteTextTool = toolMap.pasteTextTool;
 export const waitTool = toolMap.waitTool;
 export const screenshotTool = toolMap.screenshotTool;
 export const cursorPositionTool = toolMap.cursorPositionTool;
 export const setTaskStatusTool = toolMap.setTaskStatusTool;
 export const createTaskTool = toolMap.createTaskTool;
+export const applicationTool = toolMap.applicationTool;
 
 // Array of all tools
 export const openaiTools: OpenAI.Responses.FunctionTool[] = agentTools.map(

--- a/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
+++ b/packages/bytebot-ui/src/app/tasks/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import { Header } from "@/components/layout/Header";
 import { ChatContainer } from "@/components/messages/ChatContainer";
 import { DesktopContainer } from "@/components/ui/desktop-container";
@@ -8,14 +8,7 @@ import { ChatInput } from "@/components/messages/ChatInput";
 import { useChatSession } from "@/hooks/useChatSession";
 import { useScrollScreenshot } from "@/hooks/useScrollScreenshot";
 import { useParams, useRouter } from "next/navigation";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Role, TaskStatus, Model } from "@/types";
+import { Role, TaskStatus } from "@/types";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   MoreVerticalCircle01Icon,
@@ -36,8 +29,6 @@ export default function TaskPage() {
   const taskId = params.id as string;
 
   const chatContainerRef = useRef<HTMLDivElement>(null);
-  const [models, setModels] = useState<Model[]>([]);
-  const [selectedModel, setSelectedModel] = useState<Model | null>(null);
   const {
     messages,
     groupedMessages,
@@ -92,16 +83,6 @@ export default function TaskPage() {
     });
     return map;
   }, [messages]);
-
-  useEffect(() => {
-    fetch("/api/tasks/models")
-      .then((res) => res.json())
-      .then((data) => {
-        setModels(data);
-        if (data.length > 0) setSelectedModel(data[0]);
-      })
-      .catch((err) => console.error("Failed to load models", err));
-  }, []);
 
   // Redirect if task ID doesn't match current task
   useEffect(() => {

--- a/packages/bytebot-ui/src/components/messages/content/ComputerToolContentNormal.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ComputerToolContentNormal.tsx
@@ -9,6 +9,7 @@ import {
   isScrollToolUseBlock,
   isApplicationToolUseBlock,
   Application,
+  isPasteTextToolUseBlock,
 } from "@bytebot/shared";
 import { getIcon, getLabel } from "./ComputerToolUtils";
 
@@ -43,7 +44,7 @@ function ToolDetailsNormal({ block }: { block: ComputerToolUseContentBlock }) {
         <p className={baseClasses}>{String(block.input.keys.join(" + "))}</p>
       )}
 
-      {isTypeTextToolUseBlock(block) && (
+      {(isTypeTextToolUseBlock(block) || isPasteTextToolUseBlock(block)) && (
         <p className={baseClasses}>
           {String(
             block.input.isSensitive

--- a/packages/bytebot-ui/src/components/messages/content/ComputerToolContentNormal.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ComputerToolContentNormal.tsx
@@ -7,6 +7,8 @@ import {
   isPressKeysToolUseBlock,
   isWaitToolUseBlock,
   isScrollToolUseBlock,
+  isApplicationToolUseBlock,
+  Application,
 } from "@bytebot/shared";
 import { getIcon, getLabel } from "./ComputerToolUtils";
 
@@ -14,18 +16,33 @@ interface ComputerToolContentNormalProps {
   block: ComputerToolUseContentBlock;
 }
 
+const applicationMap: Record<Application, string> = {
+  firefox: "Firefox",
+  "1password": "1Password",
+  thunderbird: "Thunderbird",
+  vscode: "Visual Studio Code",
+  terminal: "Terminal",
+  directory: "File Manager",
+  desktop: "Desktop",
+};
+
 function ToolDetailsNormal({ block }: { block: ComputerToolUseContentBlock }) {
-  const baseClasses = "px-1 py-0.5 text-[12px] text-bytebot-bronze-light-11 bg-bytebot-red-light-1 border border-bytebot-bronze-light-7 rounded-md";
+  const baseClasses =
+    "px-1 py-0.5 text-[12px] text-bytebot-bronze-light-11 bg-bytebot-red-light-1 border border-bytebot-bronze-light-7 rounded-md";
 
   return (
     <>
-      {/* Text for type and key actions */}
-      {(isTypeKeysToolUseBlock(block) || isPressKeysToolUseBlock(block)) && (
+      {isApplicationToolUseBlock(block) && (
         <p className={baseClasses}>
-          {String(block.input.keys.join(" + "))}
+          {applicationMap[block.input.application as Application]}
         </p>
       )}
-      
+
+      {/* Text for type and key actions */}
+      {(isTypeKeysToolUseBlock(block) || isPressKeysToolUseBlock(block)) && (
+        <p className={baseClasses}>{String(block.input.keys.join(" + "))}</p>
+      )}
+
       {isTypeTextToolUseBlock(block) && (
         <p className={baseClasses}>
           {String(
@@ -35,23 +52,20 @@ function ToolDetailsNormal({ block }: { block: ComputerToolUseContentBlock }) {
           )}
         </p>
       )}
-      
+
       {/* Duration for wait actions */}
       {isWaitToolUseBlock(block) && (
-        <p className={baseClasses}>
-          {`${block.input.duration}ms`}
-        </p>
+        <p className={baseClasses}>{`${block.input.duration}ms`}</p>
       )}
-      
+
       {/* Coordinates for click/mouse actions */}
       {block.input.coordinates && (
         <p className={baseClasses}>
-          {(block.input.coordinates as { x: number; y: number }).x},
-          {" "}
+          {(block.input.coordinates as { x: number; y: number }).x},{" "}
           {(block.input.coordinates as { x: number; y: number }).y}
         </p>
       )}
-      
+
       {/* Start and end coordinates for path actions */}
       {"path" in block.input &&
         Array.isArray(block.input.path) &&
@@ -64,7 +78,7 @@ function ToolDetailsNormal({ block }: { block: ComputerToolUseContentBlock }) {
             {block.input.path[block.input.path.length - 1].y}
           </p>
         )}
-      
+
       {/* Scroll information */}
       {isScrollToolUseBlock(block) && (
         <p className={baseClasses}>
@@ -75,24 +89,26 @@ function ToolDetailsNormal({ block }: { block: ComputerToolUseContentBlock }) {
   );
 }
 
-export function ComputerToolContentNormal({ block }: ComputerToolContentNormalProps) {
+export function ComputerToolContentNormal({
+  block,
+}: ComputerToolContentNormalProps) {
   // Don't render screenshot tool use blocks here - they're handled separately
   if (getLabel(block) === "Screenshot") {
     return null;
   }
 
   return (
-    <div className="max-w-4/5 mb-3">
+    <div className="mb-3 max-w-4/5">
       <div className="flex items-center gap-2">
         <HugeiconsIcon
           icon={getIcon(block)}
-          className="h-4 w-4 text-bytebot-bronze-dark-9"
+          className="text-bytebot-bronze-dark-9 h-4 w-4"
         />
-        <p className="text-xs text-bytebot-bronze-light-11">
+        <p className="text-bytebot-bronze-light-11 text-xs">
           {getLabel(block)}
         </p>
         <ToolDetailsNormal block={block} />
       </div>
     </div>
   );
-} 
+}

--- a/packages/bytebot-ui/src/components/messages/content/ComputerToolUtils.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ComputerToolUtils.tsx
@@ -6,6 +6,7 @@ import {
   MouseRightClick06Icon,
   TimeQuarter02Icon,
   BrowserIcon,
+  FilePasteIcon,
 } from "@hugeicons/core-free-icons";
 import {
   ComputerToolUseContentBlock,
@@ -22,6 +23,7 @@ import {
   isPressMouseToolUseBlock,
   isTraceMouseToolUseBlock,
   isApplicationToolUseBlock,
+  isPasteTextToolUseBlock,
 } from "@bytebot/shared";
 
 // Define the IconType for proper type checking
@@ -32,7 +34,8 @@ export type IconType =
   | typeof TypeCursorIcon
   | typeof MouseRightClick06Icon
   | typeof TimeQuarter02Icon
-  | typeof BrowserIcon;
+  | typeof BrowserIcon
+  | typeof FilePasteIcon;
 
 export function getIcon(block: ComputerToolUseContentBlock): IconType {
   if (isScreenshotToolUseBlock(block)) {
@@ -49,6 +52,10 @@ export function getIcon(block: ComputerToolUseContentBlock): IconType {
     isPressKeysToolUseBlock(block)
   ) {
     return TypeCursorIcon;
+  }
+
+  if (isPasteTextToolUseBlock(block)) {
+    return FilePasteIcon;
   }
 
   if (
@@ -89,6 +96,10 @@ export function getLabel(block: ComputerToolUseContentBlock) {
 
   if (isTypeTextToolUseBlock(block)) {
     return "Type";
+  }
+
+  if (isPasteTextToolUseBlock(block)) {
+    return "Paste";
   }
 
   if (isPressKeysToolUseBlock(block)) {

--- a/packages/bytebot-ui/src/components/messages/content/ComputerToolUtils.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ComputerToolUtils.tsx
@@ -5,6 +5,7 @@ import {
   TypeCursorIcon,
   MouseRightClick06Icon,
   TimeQuarter02Icon,
+  BrowserIcon,
 } from "@hugeicons/core-free-icons";
 import {
   ComputerToolUseContentBlock,
@@ -30,7 +31,8 @@ export type IconType =
   | typeof Cursor02Icon
   | typeof TypeCursorIcon
   | typeof MouseRightClick06Icon
-  | typeof TimeQuarter02Icon;
+  | typeof TimeQuarter02Icon
+  | typeof BrowserIcon;
 
 export function getIcon(block: ComputerToolUseContentBlock): IconType {
   if (isScreenshotToolUseBlock(block)) {
@@ -63,6 +65,10 @@ export function getIcon(block: ComputerToolUseContentBlock): IconType {
     }
 
     return Cursor02Icon;
+  }
+
+  if (isApplicationToolUseBlock(block)) {
+    return BrowserIcon;
   }
 
   return User03Icon;
@@ -131,8 +137,8 @@ export function getLabel(block: ComputerToolUseContentBlock) {
   }
 
   if (isApplicationToolUseBlock(block)) {
-    return "Open App";
+    return "Open Application";
   }
 
   return "Unknown";
-} 
+}

--- a/packages/bytebot-ui/src/components/messages/content/ComputerToolUtils.tsx
+++ b/packages/bytebot-ui/src/components/messages/content/ComputerToolUtils.tsx
@@ -20,6 +20,7 @@ import {
   isDragMouseToolUseBlock,
   isPressMouseToolUseBlock,
   isTraceMouseToolUseBlock,
+  isApplicationToolUseBlock,
 } from "@bytebot/shared";
 
 // Define the IconType for proper type checking
@@ -127,6 +128,10 @@ export function getLabel(block: ComputerToolUseContentBlock) {
 
   if (isTraceMouseToolUseBlock(block)) {
     return "Trace Mouse";
+  }
+
+  if (isApplicationToolUseBlock(block)) {
+    return "Open App";
   }
 
   return "Unknown";

--- a/packages/bytebotd/Dockerfile
+++ b/packages/bytebotd/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     xvfb x11vnc xauth x11-xserver-utils \
     x11-apps sudo software-properties-common \
     # Desktop environment 
-    xfce4 xfce4-goodies dbus \
+    xfce4 xfce4-goodies dbus wmctrl \
     # Display manager with autologin capability
     lightdm \
     # Development tools

--- a/packages/bytebotd/Dockerfile
+++ b/packages/bytebotd/Dockerfile
@@ -170,6 +170,7 @@ RUN apt-get update && \
         libxrandr-dev \
         libxkbcommon-dev \
         libxkbcommon-x11-dev \
+        xclip \
         git build-essential && \
     rm -rf /var/lib/apt/lists/*
 

--- a/packages/bytebotd/src/computer-use/computer-use.service.ts
+++ b/packages/bytebotd/src/computer-use/computer-use.service.ts
@@ -17,6 +17,7 @@ import {
   TypeTextAction,
   WaitAction,
   ApplicationAction,
+  Application,
 } from '@bytebot/shared';
 
 @Injectable()
@@ -248,32 +249,43 @@ export class ComputerUseService {
     }
 
     const commandMap: Record<string, string> = {
+      firefox: 'firefox-esr',
+      '1password': '1password',
+      thunderbird: 'thunderbird',
+      vscode: 'code',
+      terminal: 'xfce4-terminal',
+      directory: 'thunar',
+    };
+
+    const processMap: Record<Application, string> = {
       firefox: 'Navigator.firefox-esr',
       '1password': '1password.1Password',
       thunderbird: 'Mail.thunderbird',
       vscode: 'code',
       terminal: 'xfce4-terminal.Xfce4-Terminal',
       directory: 'Thunar',
+      desktop: 'xfce4-desktop.Xfce4-Desktop',
     };
 
-    const cmd = commandMap[action.application];
-    if (!cmd) {
-      throw new Error(`Unknown application: ${action.application}`);
-    }
-
     // check if the application is already open using wmctrl -lx
-    const result = await exec(`wmctrl -lx | grep ${action.application}`);
+    const result = await exec(
+      `wmctrl -lx | grep ${processMap[action.application]}`,
+    );
     if (result.stdout) {
       // application is already open
       this.logger.log(`Application ${action.application} is already open`);
       // focus the application in fullscreen
-      await exec(`wmctrl -xa ${cmd} -e 0 -b add,maximized_vert,maximized_horz`);
+      await exec(
+        `wmctrl -xa ${processMap[action.application]} -e 0 -b add,maximized_vert,maximized_horz`,
+      );
       return;
     }
 
     // application is not open, open it
-    await exec(`${cmd} &`);
+    await exec(`nohup ${commandMap[action.application]} > /dev/null 2>&1 &`);
     this.logger.log(`Application ${action.application} opened`);
-    await exec(`wmctrl -xa ${cmd} -e 0 -b add,maximized_vert,maximized_horz`);
+    await exec(
+      `wmctrl -xa ${processMap[action.application]} -e 0 -b add,maximized_vert,maximized_horz`,
+    );
   }
 }

--- a/packages/bytebotd/src/computer-use/dto/base.dto.ts
+++ b/packages/bytebotd/src/computer-use/dto/base.dto.ts
@@ -25,3 +25,11 @@ export enum ScrollDirection {
   LEFT = 'left',
   RIGHT = 'right',
 }
+
+export enum ApplicationName {
+  FIREFOX = 'firefox',
+  ONEPASSWORD = '1password',
+  THUNDERBIRD = 'thunderbird',
+  VSCODE = 'vscode',
+  TERMINAL = 'terminal',
+}

--- a/packages/bytebotd/src/computer-use/dto/base.dto.ts
+++ b/packages/bytebotd/src/computer-use/dto/base.dto.ts
@@ -32,4 +32,6 @@ export enum ApplicationName {
   THUNDERBIRD = 'thunderbird',
   VSCODE = 'vscode',
   TERMINAL = 'terminal',
+  DESKTOP = 'desktop',
+  DIRECTORY = 'directory',
 }

--- a/packages/bytebotd/src/computer-use/dto/computer-action-validation.pipe.ts
+++ b/packages/bytebotd/src/computer-use/dto/computer-action-validation.pipe.ts
@@ -16,6 +16,7 @@ import {
   TypeKeysActionDto,
   PressKeysActionDto,
   TypeTextActionDto,
+  PasteTextActionDto,
   WaitActionDto,
   ScreenshotActionDto,
   CursorPositionActionDto,
@@ -57,6 +58,9 @@ export class ComputerActionValidationPipe implements PipeTransform {
         break;
       case 'type_text':
         dto = plainToClass(TypeTextActionDto, value);
+        break;
+      case 'paste_text':
+        dto = plainToClass(PasteTextActionDto, value);
         break;
       case 'wait':
         dto = plainToClass(WaitActionDto, value);

--- a/packages/bytebotd/src/computer-use/dto/computer-action-validation.pipe.ts
+++ b/packages/bytebotd/src/computer-use/dto/computer-action-validation.pipe.ts
@@ -19,6 +19,7 @@ import {
   WaitActionDto,
   ScreenshotActionDto,
   CursorPositionActionDto,
+  ApplicationActionDto,
 } from './computer-action.dto';
 
 @Injectable()
@@ -65,6 +66,9 @@ export class ComputerActionValidationPipe implements PipeTransform {
         break;
       case 'cursor_position':
         dto = plainToClass(CursorPositionActionDto, value);
+        break;
+      case 'application':
+        dto = plainToClass(ApplicationActionDto, value);
         break;
       default:
         throw new BadRequestException(`Unknown action: ${value.action}`);

--- a/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
+++ b/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
@@ -165,6 +165,14 @@ export class TypeTextActionDto extends BaseActionDto {
   delay?: number;
 }
 
+export class PasteTextActionDto extends BaseActionDto {
+  @IsIn(['paste_text'])
+  action: 'paste_text';
+
+  @IsString()
+  text: string;
+}
+
 export class WaitActionDto extends BaseActionDto {
   @IsIn(['wait'])
   action: 'wait';

--- a/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
+++ b/packages/bytebotd/src/computer-use/dto/computer-action.dto.ts
@@ -14,6 +14,7 @@ import {
   CoordinatesDto,
   PressType,
   ScrollDirection,
+  ApplicationName,
 } from './base.dto';
 
 /**
@@ -183,6 +184,14 @@ export class CursorPositionActionDto extends BaseActionDto {
   action: 'cursor_position';
 }
 
+export class ApplicationActionDto extends BaseActionDto {
+  @IsIn(['application'])
+  action: 'application';
+
+  @IsEnum(ApplicationName)
+  application: ApplicationName;
+}
+
 // Union type for all computer actions
 export type ComputerActionDto =
   | MoveMouseActionDto
@@ -196,4 +205,5 @@ export type ComputerActionDto =
   | TypeTextActionDto
   | WaitActionDto
   | ScreenshotActionDto
-  | CursorPositionActionDto;
+  | CursorPositionActionDto
+  | ApplicationActionDto;

--- a/packages/bytebotd/src/mcp/computer-use.tools.ts
+++ b/packages/bytebotd/src/mcp/computer-use.tools.ts
@@ -427,7 +427,8 @@ V, W, X, Y, Z
 
   @Tool({
     name: 'computer_type_text',
-    description: 'Simulates typing a string of text character by character.',
+    description:
+      'Types a string of text character by character. Useful for strings less than 25 characters, or passwords/sensitive form fields.',
     parameters: z.object({
       text: z.string().describe('The text string to type.'),
       delay: z
@@ -446,6 +447,30 @@ V, W, X, Y, Z
           {
             type: 'text',
             text: `Error typing text: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
+    name: 'computer_paste_text',
+    description:
+      'Copies text to the clipboard and pastes it. Useful for large text or special characters not on the standard keyboard.',
+    parameters: z.object({
+      text: z.string().describe('The text string to paste.'),
+    }),
+  })
+  async pasteText({ text }: { text: string }) {
+    try {
+      await this.computerUse.action({ action: 'paste_text', text });
+      return { content: [{ type: 'text', text: 'text pasted' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error pasting text: ${(err as Error).message}`,
           },
         ],
       };

--- a/packages/bytebotd/src/mcp/computer-use.tools.ts
+++ b/packages/bytebotd/src/mcp/computer-use.tools.ts
@@ -489,13 +489,22 @@ V, W, X, Y, Z
         'thunderbird',
         'vscode',
         'terminal',
+        'desktop',
+        'directory',
       ]),
     }),
   })
   async application({
     application,
   }: {
-    application: 'firefox' | '1password' | 'thunderbird' | 'vscode' | 'terminal';
+    application:
+      | 'firefox'
+      | '1password'
+      | 'thunderbird'
+      | 'vscode'
+      | 'terminal'
+      | 'desktop'
+      | 'directory';
   }) {
     try {
       await this.computerUse.action({ action: 'application', application });

--- a/packages/bytebotd/src/mcp/computer-use.tools.ts
+++ b/packages/bytebotd/src/mcp/computer-use.tools.ts
@@ -428,7 +428,7 @@ V, W, X, Y, Z
   @Tool({
     name: 'computer_type_text',
     description:
-      'Types a string of text character by character. Useful for strings less than 25 characters, or passwords/sensitive form fields.',
+      'Types a string of text character by character. Use this tool for strings less than 25 characters, or passwords/sensitive form fields.',
     parameters: z.object({
       text: z.string().describe('The text string to type.'),
       delay: z
@@ -456,7 +456,7 @@ V, W, X, Y, Z
   @Tool({
     name: 'computer_paste_text',
     description:
-      'Copies text to the clipboard and pastes it. Useful for large text or special characters not on the standard keyboard.',
+      'Copies text to the clipboard and pastes it. Use this tool for typing long text strings or special characters not on the standard keyboard.',
     parameters: z.object({
       text: z.string().describe('The text string to paste.'),
     }),

--- a/packages/bytebotd/src/mcp/computer-use.tools.ts
+++ b/packages/bytebotd/src/mcp/computer-use.tools.ts
@@ -479,6 +479,40 @@ V, W, X, Y, Z
   }
 
   @Tool({
+    name: 'computer_application',
+    description:
+      'Opens or switches to the specified application and maximizes it.',
+    parameters: z.object({
+      application: z.enum([
+        'firefox',
+        '1password',
+        'thunderbird',
+        'vscode',
+        'terminal',
+      ]),
+    }),
+  })
+  async application({
+    application,
+  }: {
+    application: 'firefox' | '1password' | 'thunderbird' | 'vscode' | 'terminal';
+  }) {
+    try {
+      await this.computerUse.action({ action: 'application', application });
+      return { content: [{ type: 'text', text: 'application opened' }] };
+    } catch (err) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error opening application: ${(err as Error).message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  @Tool({
     name: 'computer_screenshot',
     description: 'Captures a screenshot of the current screen.',
   })

--- a/packages/shared/src/types/computerAction.types.ts
+++ b/packages/shared/src/types/computerAction.types.ts
@@ -58,6 +58,11 @@ export type TypeKeysAction = {
   delay?: number;
 };
 
+export type PasteTextAction = {
+  action: "paste_text";
+  text: string;
+};
+
 export type PressKeysAction = {
   action: "press_keys";
   keys: string[];
@@ -100,6 +105,7 @@ export type ComputerAction =
   | TypeKeysAction
   | PressKeysAction
   | TypeTextAction
+  | PasteTextAction
   | WaitAction
   | ScreenshotAction
   | CursorPositionAction

--- a/packages/shared/src/types/computerAction.types.ts
+++ b/packages/shared/src/types/computerAction.types.ts
@@ -1,6 +1,14 @@
 export type Coordinates = { x: number; y: number };
 export type Button = "left" | "right" | "middle";
 export type Press = "up" | "down";
+export type Application =
+  | "firefox"
+  | "1password"
+  | "thunderbird"
+  | "vscode"
+  | "terminal"
+  | "desktop"
+  | "directory";
 
 // Define individual computer action types
 export type MoveMouseAction = {
@@ -78,7 +86,7 @@ export type CursorPositionAction = {
 
 export type ApplicationAction = {
   action: "application";
-  application: string;
+  application: Application;
 };
 
 // Define the union type using the individual action types

--- a/packages/shared/src/types/computerAction.types.ts
+++ b/packages/shared/src/types/computerAction.types.ts
@@ -76,6 +76,11 @@ export type CursorPositionAction = {
   action: "cursor_position";
 };
 
+export type ApplicationAction = {
+  action: "application";
+  application: string;
+};
+
 // Define the union type using the individual action types
 export type ComputerAction =
   | MoveMouseAction
@@ -89,4 +94,5 @@ export type ComputerAction =
   | TypeTextAction
   | WaitAction
   | ScreenshotAction
-  | CursorPositionAction;
+  | CursorPositionAction
+  | ApplicationAction;

--- a/packages/shared/src/types/messageContent.types.ts
+++ b/packages/shared/src/types/messageContent.types.ts
@@ -126,6 +126,14 @@ export type TypeTextToolUseBlock = ToolUseContentBlock & {
   };
 };
 
+export type PasteTextToolUseBlock = ToolUseContentBlock & {
+  name: "computer_paste_text";
+  input: {
+    text: string;
+    isSensitive?: boolean;
+  };
+};
+
 export type WaitToolUseBlock = ToolUseContentBlock & {
   name: "computer_wait";
   input: {
@@ -156,11 +164,11 @@ export type ComputerToolUseContentBlock =
   | TypeKeysToolUseBlock
   | PressKeysToolUseBlock
   | TypeTextToolUseBlock
+  | PasteTextToolUseBlock
   | WaitToolUseBlock
   | ScreenshotToolUseBlock
   | DragMouseToolUseBlock
   | ScrollToolUseBlock
-  | TypeTextToolUseBlock
   | CursorPositionToolUseBlock
   | ApplicationToolUseBlock;
 

--- a/packages/shared/src/types/messageContent.types.ts
+++ b/packages/shared/src/types/messageContent.types.ts
@@ -141,6 +141,13 @@ export type CursorPositionToolUseBlock = ToolUseContentBlock & {
   name: "computer_cursor_position";
 };
 
+export type ApplicationToolUseBlock = ToolUseContentBlock & {
+  name: "computer_application";
+  input: {
+    application: string;
+  };
+};
+
 export type ComputerToolUseContentBlock =
   | MoveMouseToolUseBlock
   | TraceMouseToolUseBlock
@@ -154,7 +161,8 @@ export type ComputerToolUseContentBlock =
   | DragMouseToolUseBlock
   | ScrollToolUseBlock
   | TypeTextToolUseBlock
-  | CursorPositionToolUseBlock;
+  | CursorPositionToolUseBlock
+  | ApplicationToolUseBlock;
 
 export type SetTaskStatusToolUseBlock = ToolUseContentBlock & {
   name: "set_task_status";

--- a/packages/shared/src/utils/computerAction.utils.ts
+++ b/packages/shared/src/utils/computerAction.utils.ts
@@ -13,6 +13,7 @@ import {
   ScreenshotAction,
   CursorPositionAction,
   ApplicationAction,
+  PasteTextAction,
 } from "../types/computerAction.types";
 import {
   ComputerToolUseContentBlock,
@@ -230,6 +231,15 @@ export function convertTypeTextActionToToolUseBlock(
   );
 }
 
+export function convertPasteTextActionToToolUseBlock(
+  action: PasteTextAction,
+  toolUseId: string
+): ComputerToolUseContentBlock {
+  return createToolUseBlock("computer_paste_text", toolUseId, {
+    text: action.text,
+  });
+}
+
 export function convertWaitActionToToolUseBlock(
   action: WaitAction,
   toolUseId: string
@@ -255,7 +265,7 @@ export function convertCursorPositionActionToToolUseBlock(
 
 export function convertApplicationActionToToolUseBlock(
   action: ApplicationAction,
-  toolUseId: string,
+  toolUseId: string
 ): ComputerToolUseContentBlock {
   return createToolUseBlock("computer_application", toolUseId, {
     application: action.application,
@@ -288,6 +298,8 @@ export function convertComputerActionToToolUseBlock(
       return convertPressKeysActionToToolUseBlock(action, toolUseId);
     case "type_text":
       return convertTypeTextActionToToolUseBlock(action, toolUseId);
+    case "paste_text":
+      return convertPasteTextActionToToolUseBlock(action, toolUseId);
     case "wait":
       return convertWaitActionToToolUseBlock(action, toolUseId);
     case "screenshot":

--- a/packages/shared/src/utils/computerAction.utils.ts
+++ b/packages/shared/src/utils/computerAction.utils.ts
@@ -12,6 +12,7 @@ import {
   WaitAction,
   ScreenshotAction,
   CursorPositionAction,
+  ApplicationAction,
 } from "../types/computerAction.types";
 import {
   ComputerToolUseContentBlock,
@@ -58,6 +59,8 @@ export const isScreenshotAction =
   createActionTypeGuard<ScreenshotAction>("screenshot");
 export const isCursorPositionAction =
   createActionTypeGuard<CursorPositionAction>("cursor_position");
+export const isApplicationAction =
+  createActionTypeGuard<ApplicationAction>("application");
 
 /**
  * Base converter for creating tool use blocks
@@ -250,6 +253,15 @@ export function convertCursorPositionActionToToolUseBlock(
   return createToolUseBlock("computer_cursor_position", toolUseId, {});
 }
 
+export function convertApplicationActionToToolUseBlock(
+  action: ApplicationAction,
+  toolUseId: string,
+): ComputerToolUseContentBlock {
+  return createToolUseBlock("computer_application", toolUseId, {
+    application: action.application,
+  });
+}
+
 /**
  * Generic converter that handles all action types
  */
@@ -282,6 +294,8 @@ export function convertComputerActionToToolUseBlock(
       return convertScreenshotActionToToolUseBlock(action, toolUseId);
     case "cursor_position":
       return convertCursorPositionActionToToolUseBlock(action, toolUseId);
+    case "application":
+      return convertApplicationActionToToolUseBlock(action, toolUseId);
     default:
       const exhaustiveCheck: never = action;
       throw new Error(

--- a/packages/shared/src/utils/messageContent.utils.ts
+++ b/packages/shared/src/utils/messageContent.utils.ts
@@ -18,6 +18,7 @@ import {
   CursorPositionToolUseBlock,
   DragMouseToolUseBlock,
   ScrollToolUseBlock,
+  ApplicationToolUseBlock,
   SetTaskStatusToolUseBlock,
   CreateTaskToolUseBlock,
   ThinkingContentBlock,
@@ -389,6 +390,17 @@ export function isScreenshotToolUseBlock(
 
   const block = obj as Record<string, any>;
   return block.name === "computer_screenshot";
+}
+
+export function isApplicationToolUseBlock(
+  obj: unknown,
+): obj is ApplicationToolUseBlock {
+  if (!isComputerToolUseContentBlock(obj)) {
+    return false;
+  }
+
+  const block = obj as Record<string, any>;
+  return block.name === "computer_application";
 }
 
 export function isSetTaskStatusToolUseBlock(

--- a/packages/shared/src/utils/messageContent.utils.ts
+++ b/packages/shared/src/utils/messageContent.utils.ts
@@ -23,6 +23,7 @@ import {
   CreateTaskToolUseBlock,
   ThinkingContentBlock,
   RedactedThinkingContentBlock,
+  PasteTextToolUseBlock,
 } from "../types/messageContent.types";
 
 /**
@@ -362,6 +363,17 @@ export function isTypeTextToolUseBlock(
   return block.name === "computer_type_text";
 }
 
+export function isPasteTextToolUseBlock(
+  obj: unknown
+): obj is PasteTextToolUseBlock {
+  if (!isComputerToolUseContentBlock(obj)) {
+    return false;
+  }
+
+  const block = obj as Record<string, any>;
+  return block.name === "computer_paste_text";
+}
+
 /**
  * Type guard to check if an object is a WaitToolUseBlock
  * @param obj The object to validate
@@ -393,7 +405,7 @@ export function isScreenshotToolUseBlock(
 }
 
 export function isApplicationToolUseBlock(
-  obj: unknown,
+  obj: unknown
 ): obj is ApplicationToolUseBlock {
   if (!isComputerToolUseContentBlock(obj)) {
     return false;


### PR DESCRIPTION
## Summary
- rename `open_application` action and related types to `application`
- update service, tools, and utilities to use the new name
- adjust the agent and UI to work with `computer_application`

## Testing
- `npm run build --prefix packages/shared`
- `npm run build --prefix packages/bytebotd` *(fails: `nest` not found)*
- `npm run build --prefix packages/bytebot-agent` *(fails: needs `prisma`)*
- `npm run build --prefix packages/bytebot-ui` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6879391f7df48329a85d8eaf7830168f