### PR TITLE
ci: add workflow_dispatch to Build UI

### DIFF
--- a/.github/workflows/build-ui.yaml
+++ b/.github/workflows/build-ui.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - "packages/bytebot-ui/**"
       - "packages/shared/**"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Add manual workflow_dispatch trigger so Build UI can be run from the GitHub UI or via CLI.